### PR TITLE
LW-783 Add CodePipeline Orchestration

### DIFF
--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -22,18 +22,22 @@ const app = new cdk.App({
 app.node.applyAspect(new StackTags())
 
 const stage = app.node.tryGetContext('stage') || 'dev'
+const sharedProps = {
+  createDns: app.node.tryGetContext('createDns') === undefined ? true : app.node.tryGetContext('createDns') === 'true',
+  domainStackName: app.node.tryGetContext('domainStackName') || 'libraries-domain',
+}
 
 // tslint:disable-next-line:no-unused-expression
 new UsurperStack(app, 'AppStack', {
+  ...sharedProps,
   stackName: app.node.tryGetContext('serviceStackName') || `usurper-${stage}`,
   buildPath: app.node.tryGetContext('usurperBuildPath') || '../usurper/build',
-  createDns: app.node.tryGetContext('createDns') === undefined ? true : app.node.tryGetContext('createDns') === 'true',
-  domainStackName: app.node.tryGetContext('domainStackName') || 'libraries-domain',
-  hostnamePrefix: app.node.tryGetContext('hostnamePrefix') || `usurper-${stage}`,
   stage,
+  hostnamePrefix: app.node.tryGetContext('hostnamePrefix') || `usurper-${stage}`,
 })
 // tslint:disable-next-line:no-unused-expression
 new UsurperPipelineStack(app, 'PipelineStack', {
+  ...sharedProps,
   stackName: app.node.tryGetContext('pipelineStackName') || `usurper-pipeline`,
   gitOwner: app.node.tryGetContext('gitOwner'),
   gitTokenPath: app.node.tryGetContext('gitTokenPath'),

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -3,6 +3,7 @@ import cdk = require('@aws-cdk/core')
 import { StackTags } from '@ndlib/ndlib-cdk'
 import { execSync } from 'child_process'
 import { UsurperPipelineStack } from '../src/usurper-pipeline-stack'
+import { UsurperPrepPipelineStack } from '../src/usurper-prep-pipeline-stack'
 import { UsurperStack } from '../src/usurper-stack'
 
 // The context values here are defaults only. Passing context in cli will override these
@@ -35,10 +36,9 @@ new UsurperStack(app, 'AppStack', {
   stage,
   hostnamePrefix: app.node.tryGetContext('hostnamePrefix') || `usurper-${stage}`,
 })
-// tslint:disable-next-line:no-unused-expression
-new UsurperPipelineStack(app, 'PipelineStack', {
+
+const pipelineProps = {
   ...sharedProps,
-  stackName: app.node.tryGetContext('pipelineStackName') || `usurper-pipeline`,
   gitOwner: app.node.tryGetContext('gitOwner'),
   gitTokenPath: app.node.tryGetContext('gitTokenPath'),
   usurperRepository: app.node.tryGetContext('usurperRepository'),
@@ -50,4 +50,14 @@ new UsurperPipelineStack(app, 'PipelineStack', {
   sentryTokenPath: app.node.tryGetContext('sentryTokenPath'),
   sentryOrg: app.node.tryGetContext('sentryOrg'),
   sentryProject: app.node.tryGetContext('sentryProject'),
+}
+// tslint:disable-next-line:no-unused-expression
+new UsurperPipelineStack(app, 'PipelineStack', {
+  ...pipelineProps,
+  stackName: app.node.tryGetContext('pipelineStackName') || `usurper-pipeline`,
+})
+// tslint:disable-next-line:no-unused-expression
+new UsurperPrepPipelineStack(app, 'PrepPipelineStack', {
+  ...pipelineProps,
+  stackName: app.node.tryGetContext('pipelineStackName') || `usurper-prep-pipeline`,
 })

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -1,9 +1,29 @@
 #!/usr/bin/env node
 import cdk = require('@aws-cdk/core')
+import { execSync } from 'child_process'
 import { StackTags } from 'ndlib-cdk'
+import { UsurperPipelineStack } from '../src/usurper-pipeline-stack'
 import { UsurperStack } from '../src/usurper-stack'
 
 const app = new cdk.App()
+
+if (!app.node.tryGetContext('owner')) {
+  app.node.setContext(
+    'owner',
+    execSync('id -un')
+      .toString()
+      .trim(),
+  )
+}
+if (!app.node.tryGetContext('contact')) {
+  app.node.setContext(
+    'contact',
+    execSync('id -un')
+      .toString()
+      .trim() + '@nd.edu',
+  )
+}
+
 app.node.applyAspect(new StackTags())
 
 const stage = app.node.tryGetContext('stage') || 'dev'
@@ -16,4 +36,19 @@ new UsurperStack(app, 'AppStack', {
   domainStackName: app.node.tryGetContext('domainStackName') || 'libraries-domain',
   hostnamePrefix: app.node.tryGetContext('hostnamePrefix') || `usurper-${stage}`,
   stage,
+})
+// tslint:disable-next-line:no-unused-expression
+new UsurperPipelineStack(app, 'PipelineStack', {
+  stackName: app.node.tryGetContext('pipelineStackName') || `usurper-pipeline`,
+  gitOwner: app.node.tryGetContext('gitOwner'),
+  gitTokenPath: app.node.tryGetContext('gitTokenPath'),
+  usurperRepository: app.node.tryGetContext('usurperRepository'),
+  usurperBranch: app.node.tryGetContext('usurperBranch'),
+  blueprintsRepository: app.node.tryGetContext('blueprintsRepository'),
+  blueprintsBranch: app.node.tryGetContext('blueprintsBranch'),
+  contact: app.node.tryGetContext('contact'),
+  owner: app.node.tryGetContext('owner'),
+  sentryTokenPath: app.node.tryGetContext('sentryTokenPath'),
+  sentryOrg: app.node.tryGetContext('sentryOrg'),
+  sentryProject: app.node.tryGetContext('sentryProject'),
 })

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -28,7 +28,6 @@ const sharedProps = {
   domainStackName: app.node.tryGetContext('domainStackName') || 'libraries-domain',
 }
 
-// tslint:disable-next-line:no-unused-expression
 new UsurperStack(app, 'AppStack', {
   ...sharedProps,
   stackName: app.node.tryGetContext('serviceStackName') || `usurper-${stage}`,
@@ -51,12 +50,10 @@ const pipelineProps = {
   sentryOrg: app.node.tryGetContext('sentryOrg'),
   sentryProject: app.node.tryGetContext('sentryProject'),
 }
-// tslint:disable-next-line:no-unused-expression
 new UsurperPipelineStack(app, 'PipelineStack', {
   ...pipelineProps,
   stackName: app.node.tryGetContext('pipelineStackName') || `usurper-pipeline`,
 })
-// tslint:disable-next-line:no-unused-expression
 new UsurperPrepPipelineStack(app, 'PrepPipelineStack', {
   ...pipelineProps,
   stackName: app.node.tryGetContext('pipelineStackName') || `usurper-prep-pipeline`,

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -1,28 +1,23 @@
 #!/usr/bin/env node
 import cdk = require('@aws-cdk/core')
+import { StackTags } from '@ndlib/ndlib-cdk'
 import { execSync } from 'child_process'
-import { StackTags } from 'ndlib-cdk'
 import { UsurperPipelineStack } from '../src/usurper-pipeline-stack'
 import { UsurperStack } from '../src/usurper-stack'
 
-const app = new cdk.App()
-
-if (!app.node.tryGetContext('owner')) {
-  app.node.setContext(
-    'owner',
-    execSync('id -un')
+// The context values here are defaults only. Passing context in cli will override these
+// Normally, you want to set constant defaults in cdk.json, but these are dynamic based on the executing user.
+const app = new cdk.App({
+  context: {
+    owner: execSync('id -un')
       .toString()
       .trim(),
-  )
-}
-if (!app.node.tryGetContext('contact')) {
-  app.node.setContext(
-    'contact',
-    execSync('id -un')
-      .toString()
-      .trim() + '@nd.edu',
-  )
-}
+    contact:
+      execSync('id -un')
+        .toString()
+        .trim() + '@nd.edu',
+  },
+})
 
 app.node.applyAspect(new StackTags())
 

--- a/cdk.json
+++ b/cdk.json
@@ -9,6 +9,9 @@
     "usurperBranch": "master",
     "blueprintsRepository": "usurper-blueprints",
     "blueprintsBranch": "master",
-    "domainStackName": "libraries-domain"
+    "domainStackName": "libraries-domain",
+    "sentryTokenPath": "/all/sentry/ci-token",
+    "sentryOrg": "university-of-notre-dame-ts",
+    "sentryProject": "usurper"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,9 +33,10 @@
     "watch": "tsc-watch --onSuccess \"npm run test\""
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.9.0",
+    "@aws-cdk/assert": "^1.12.0",
     "@types/jest": "^24.0.18",
-    "aws-cdk": "^1.9.0",
+    "@types/node": "^12.7.11",
+    "aws-cdk": "^1.12.0",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",
     "ts-jest": "^24.1.0",
@@ -49,17 +50,17 @@
     "lib/**/*"
   ],
   "dependencies": {
-    "@aws-cdk/aws-certificatemanager": "^1.9.0",
-    "@aws-cdk/aws-cloudfront": "^1.9.0",
-    "@aws-cdk/aws-codebuild": "^1.9.0",
-    "@aws-cdk/aws-codepipeline": "^1.9.0",
-    "@aws-cdk/aws-codepipeline-actions": "^1.9.0",
-    "@aws-cdk/aws-iam": "^1.9.0",
-    "@aws-cdk/aws-route53": "^1.9.0",
-    "@aws-cdk/aws-s3": "^1.9.0",
-    "@aws-cdk/aws-s3-deployment": "^1.9.0",
-    "@aws-cdk/aws-sns": "^1.9.0",
-    "@aws-cdk/core": "^1.9.0",
-    "ndlib-cdk": "^1.0.2"
+    "@aws-cdk/aws-certificatemanager": "^1.12.0",
+    "@aws-cdk/aws-cloudfront": "^1.12.0",
+    "@aws-cdk/aws-codebuild": "^1.12.0",
+    "@aws-cdk/aws-codepipeline": "^1.12.0",
+    "@aws-cdk/aws-codepipeline-actions": "^1.12.0",
+    "@aws-cdk/aws-iam": "^1.12.0",
+    "@aws-cdk/aws-route53": "^1.12.0",
+    "@aws-cdk/aws-s3": "^1.12.0",
+    "@aws-cdk/aws-s3-deployment": "1.11.0",
+    "@aws-cdk/aws-sns": "^1.12.0",
+    "@aws-cdk/core": "^1.12.0",
+    "@ndlib/ndlib-cdk": "^1.0.3"
   }
 }

--- a/src/artifact-bucket.ts
+++ b/src/artifact-bucket.ts
@@ -1,0 +1,28 @@
+import { AnyPrincipal, Effect, PolicyStatement } from '@aws-cdk/aws-iam'
+import { Bucket, BucketProps } from '@aws-cdk/aws-s3'
+import cdk = require('@aws-cdk/core')
+import { RemovalPolicy } from '@aws-cdk/core'
+
+export class ArtifactBucket extends Bucket {
+  constructor(scope: cdk.Construct, id: string, props: BucketProps) {
+    const bucketProps = {
+      ...props,
+      removalPolicy: RemovalPolicy.DESTROY,
+    }
+    super(scope, id, bucketProps)
+
+    this.addToResourcePolicy(
+      new PolicyStatement({
+        principals: [new AnyPrincipal()],
+        effect: Effect.DENY,
+        actions: ['s3:*'],
+        conditions: {
+          Bool: { 'aws:SecureTransport': false },
+        },
+        resources: [this.bucketArn + '/*'],
+      }),
+    )
+  }
+}
+
+export default ArtifactBucket

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -91,7 +91,7 @@ export class UsurperBuildProject extends codebuild.PipelineProject {
           post_build: {
             commands: [
               './scripts/codebuild/post_build.sh',
-              'if [ $CODEBUILD_BUILD_SUCCEEDING = 1 ]; then yarn sentry-cli releases deploys usurper@$VERSION new -e $STAGE; fi',
+              'if [ $CODEBUILD_BUILD_SUCCEEDING = 1 ] && [ $STAGE != "prep" ]; then yarn sentry-cli releases deploys usurper@$VERSION new -e $STAGE; fi',
               'if [ $CODEBUILD_BUILD_SUCCEEDING = 1 ] && [ $STAGE = "prod" ]; then yarn sentry-cli releases finalize usurper@$VERSION; fi',
             ],
           },

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -14,14 +14,12 @@ export interface IUsurperBuildProjectProps extends codebuild.PipelineProjectProp
 
 export class UsurperBuildProject extends codebuild.PipelineProject {
   constructor(scope: cdk.Construct, id: string, props: IUsurperBuildProjectProps) {
-    super(scope, id, props)
-
-    return new codebuild.PipelineProject(this, id, {
+    const pipelineProps = {
       environment: {
         buildImage: codebuild.LinuxBuildImage.STANDARD_2_0,
         environmentVariables: {
           STACK_NAME: {
-            value: this.node.tryGetContext('serviceStackName') || `usurper-${props.stage}`,
+            value: scope.node.tryGetContext('serviceStackName') || `usurper-${props.stage}`,
             type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
           },
           CI: {
@@ -84,7 +82,8 @@ export class UsurperBuildProject extends codebuild.PipelineProject {
           files: ['build/**/*'],
         },
       }),
-    })
+    }
+    super(scope, id, pipelineProps)
   }
 }
 

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -20,6 +20,10 @@ export class UsurperBuildProject extends codebuild.PipelineProject {
       environment: {
         buildImage: codebuild.LinuxBuildImage.STANDARD_2_0,
         environmentVariables: {
+          STACK_NAME: {
+            value: this.node.tryGetContext('serviceStackName') || `usurper-${props.stage}`,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
           CI: {
             value: 'true',
             type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -92,6 +92,7 @@ export class UsurperBuildProject extends codebuild.PipelineProject {
             commands: [
               './scripts/codebuild/post_build.sh',
               'if [ $CODEBUILD_BUILD_SUCCEEDING = 1 ]; then yarn sentry-cli releases deploys usurper@$VERSION new -e $STAGE; fi',
+              'if [ $CODEBUILD_BUILD_SUCCEEDING = 1 ] && [ $STAGE = "prod" ]; then yarn sentry-cli releases finalize usurper@$VERSION; fi',
             ],
           },
         },

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -1,0 +1,87 @@
+import codebuild = require('@aws-cdk/aws-codebuild')
+import { Role } from '@aws-cdk/aws-iam'
+import cdk = require('@aws-cdk/core')
+
+export interface IUsurperBuildProjectProps extends codebuild.PipelineProjectProps {
+  readonly stage: string
+  readonly role: Role
+  readonly contact: string
+  readonly owner: string
+  readonly sentryTokenPath: string
+  readonly sentryOrg: string
+  readonly sentryProject: string
+}
+
+export class UsurperBuildProject extends codebuild.PipelineProject {
+  constructor(scope: cdk.Construct, id: string, props: IUsurperBuildProjectProps) {
+    super(scope, id, props)
+
+    return new codebuild.PipelineProject(this, id, {
+      environment: {
+        buildImage: codebuild.LinuxBuildImage.STANDARD_2_0,
+        environmentVariables: {
+          CI: {
+            value: 'true',
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+          STAGE: {
+            value: props.stage,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+          CONTACT: {
+            value: props.contact,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+          OWNER: {
+            value: props.owner,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+          SENTRY_AUTH_TOKEN: {
+            value: props.sentryTokenPath,
+            type: codebuild.BuildEnvironmentVariableType.PARAMETER_STORE,
+          },
+          SENTRY_ORG: {
+            value: props.sentryOrg,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+          SENTRY_PROJECT: {
+            value: props.sentryProject,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+        },
+      },
+      role: props.role,
+      buildSpec: codebuild.BuildSpec.fromObject({
+        version: '0.2',
+        phases: {
+          install: {
+            'runtime-versions': {
+              nodejs: 10,
+            },
+            commands: [
+              'echo "Ensure that the codebuild directory is executable"',
+              'chmod -R 755 ./scripts/codebuild/*',
+              'export BLUEPRINTS_DIR="$CODEBUILD_SRC_DIR_InfraCode"',
+              './scripts/codebuild/install.sh',
+              'yarn add @sentry/cli',
+            ],
+          },
+          pre_build: {
+            commands: ['export VERSION=$(cat ./VERSION)', './scripts/codebuild/pre_build.sh'],
+          },
+          build: {
+            commands: ['./scripts/codebuild/build.sh'],
+          },
+          post_build: {
+            commands: ['./scripts/codebuild/post_build.sh', 'yarn sentry-cli releases deploys $VERSION new -e $STAGE'],
+          },
+        },
+        artifacts: {
+          files: ['build/**/*'],
+        },
+      }),
+    })
+  }
+}
+
+export default UsurperBuildProject

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -89,7 +89,10 @@ export class UsurperBuildProject extends codebuild.PipelineProject {
             commands: ['./scripts/codebuild/build.sh'],
           },
           post_build: {
-            commands: ['./scripts/codebuild/post_build.sh', 'yarn sentry-cli releases deploys $VERSION new -e $STAGE'],
+            commands: [
+              './scripts/codebuild/post_build.sh',
+              'if [ $CODEBUILD_BUILD_SUCCEEDING = 1 ]; then yarn sentry-cli releases deploys usurper@$VERSION new -e $STAGE; fi',
+            ],
           },
         },
         artifacts: {

--- a/src/usurper-build-role.ts
+++ b/src/usurper-build-role.ts
@@ -1,0 +1,111 @@
+import { PolicyStatement, Role, RoleProps } from '@aws-cdk/aws-iam'
+import { Bucket } from '@aws-cdk/aws-s3'
+import cdk = require('@aws-cdk/core')
+import { Fn } from '@aws-cdk/core'
+
+export interface IUsurperBuildRoleProps extends RoleProps {
+  readonly artifactBucket: Bucket
+}
+
+export class UsurperBuildRole extends Role {
+  constructor(scope: cdk.Construct, id: string, props: IUsurperBuildRoleProps) {
+    super(scope, id, props)
+
+    // Allow checking what policies are attached to this role
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [this.roleArn],
+        actions: ['iam:GetRolePolicy'],
+      }),
+    )
+    // Allow modifying IAM roles related to our application
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-*')],
+        actions: [
+          'iam:GetRole',
+          'iam:CreateRole',
+          'iam:DeleteRole',
+          'iam:DeleteRolePolicy',
+          'iam:AttachRolePolicy',
+          'iam:DetachRolePolicy',
+          'iam:PutRolePolicy',
+          'iam:PassRole',
+        ],
+      }),
+    )
+    // Allow logging
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-*'),
+        ],
+        actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+      }),
+    )
+    // Allow storing artifacts in S3 buckets
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [props.artifactBucket.bucketArn],
+        actions: ['s3:ListBucket', 's3:GetObject', 's3:PutObject'],
+      }),
+    )
+    // Allow fetching details about and updating the application stack
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}-*/*')],
+        actions: [
+          'cloudformation:DescribeStacks',
+          'cloudformation:DescribeStackEvents',
+          'cloudformation:DescribeChangeSet',
+          'cloudformation:CreateChangeSet',
+          'cloudformation:ExecuteChangeSet',
+          'cloudformation:DeleteChangeSet',
+          'cloudformation:DeleteStack',
+          'cloudformation:GetTemplate',
+        ],
+      }),
+    )
+    // Allow reading some details about CDKToolkit stack so we can use the CDK CLI successfully from CodeBuild.
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*')],
+        actions: ['cloudformation:DescribeStacks'],
+      }),
+    )
+    // Allow reading exports to get urls for other related services
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: ['*'],
+        actions: ['cloudformation:ListExports'],
+      }),
+    )
+    // Allow creating and modifying cloudfront
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: ['*'],
+        actions: [
+          'cloudfront:GetDistribution',
+          'cloudfront:CreateDistribution',
+          'cloudfront:UpdateDistribution',
+          'cloudfront:TagResource',
+          'cloudfront:CreateInvalidation',
+        ],
+      }),
+    )
+    // Allow getting parameters for usurper in parameter store
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/prep/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/test/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/prod/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/sentry/*'),
+        ],
+        actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+      }),
+    )
+  }
+}
+
+export default UsurperBuildRole

--- a/src/usurper-build-role.ts
+++ b/src/usurper-build-role.ts
@@ -45,13 +45,23 @@ export class UsurperBuildRole extends Role {
     })
     this.addToPolicy(iamStatement)
 
-    // Allow logging
+    // Global resource permissions for managing cloudfront and logs
     this.addToPolicy(
       new PolicyStatement({
         resources: ['*'],
-        actions: ['logs:CreateLogGroup'],
+        actions: [
+          'cloudformation:ListExports',
+          'cloudfront:GetDistribution',
+          'cloudfront:CreateDistribution',
+          'cloudfront:UpdateDistribution',
+          'cloudfront:TagResource',
+          'cloudfront:CreateInvalidation',
+          'logs:CreateLogGroup',
+        ],
       }),
     )
+
+    // Allow logging for this stack
     this.addToPolicy(
       new PolicyStatement({
         resources: [
@@ -151,26 +161,6 @@ export class UsurperBuildRole extends Role {
       new PolicyStatement({
         resources: [Fn.sub('arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*')],
         actions: ['cloudformation:DescribeStacks'],
-      }),
-    )
-    // Allow reading exports to get urls for other related services
-    this.addToPolicy(
-      new PolicyStatement({
-        resources: ['*'],
-        actions: ['cloudformation:ListExports'],
-      }),
-    )
-    // Allow creating and modifying cloudfront
-    this.addToPolicy(
-      new PolicyStatement({
-        resources: ['*'],
-        actions: [
-          'cloudfront:GetDistribution',
-          'cloudfront:CreateDistribution',
-          'cloudfront:UpdateDistribution',
-          'cloudfront:TagResource',
-          'cloudfront:CreateInvalidation',
-        ],
       }),
     )
     // Allow creating DNS records in the domain stack's zone

--- a/src/usurper-build-role.ts
+++ b/src/usurper-build-role.ts
@@ -5,6 +5,8 @@ import { Fn } from '@aws-cdk/core'
 
 export interface IUsurperBuildRoleProps extends RoleProps {
   readonly artifactBucket: Bucket
+  readonly createDns: boolean
+  readonly domainStackName: string
 }
 
 export class UsurperBuildRole extends Role {
@@ -33,23 +35,88 @@ export class UsurperBuildRole extends Role {
           'iam:DetachRolePolicy',
           'iam:PutRolePolicy',
           'iam:PassRole',
+          'iam:TagRole',
         ],
       }),
     )
     // Allow logging
     this.addToPolicy(
       new PolicyStatement({
+        resources: ['*'],
+        actions: ['logs:CreateLogGroup'],
+      }),
+    )
+    this.addToPolicy(
+      new PolicyStatement({
         resources: [
           Fn.sub('arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-*'),
         ],
-        actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+        actions: ['logs:CreateLogStream'],
       }),
     )
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub(
+            'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-*:log-stream:*',
+          ),
+        ],
+        actions: ['logs:PutLogEvents'],
+      }),
+    )
+
     // Allow storing artifacts in S3 buckets
     this.addToPolicy(
       new PolicyStatement({
         resources: [props.artifactBucket.bucketArn, 'arn:aws:s3:::cdktoolkit-stagingbucket-*'],
-        actions: ['s3:ListBucket', 's3:GetObject', 's3:PutObject'],
+        actions: ['s3:ListBucket'],
+      }),
+    )
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [props.artifactBucket.bucketArn + '/*', 'arn:aws:s3:::cdktoolkit-stagingbucket-*/*'],
+        actions: ['s3:GetObject', 's3:PutObject'],
+      }),
+    )
+    // Allow creating and managing s3 bucket for site
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:s3:::' + serviceStackPrefix + '-prep-${AWS::AccountId}'),
+          Fn.sub('arn:aws:s3:::' + serviceStackPrefix + '-test-${AWS::AccountId}'),
+          Fn.sub('arn:aws:s3:::' + serviceStackPrefix + '-prod-${AWS::AccountId}'),
+        ],
+        actions: ['s3:CreateBucket', 's3:ListBucket*', 's3:GetBucket*', 's3:DeleteBucket*', 's3:PutBucket*'],
+      }),
+    )
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:s3:::' + serviceStackPrefix + '-prep-${AWS::AccountId}/*'),
+          Fn.sub('arn:aws:s3:::' + serviceStackPrefix + '-test-${AWS::AccountId}/*'),
+          Fn.sub('arn:aws:s3:::' + serviceStackPrefix + '-prod-${AWS::AccountId}/*'),
+        ],
+        actions: ['s3:GetObject*', 's3:DeleteObject*', 's3:PutObject*', 's3:Abort*', 's3:ReplicateTags'],
+      }),
+    )
+    // Allow adding to cloudfront logs bucket
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: ['arn:aws:s3:::' + Fn.importValue('wse-web-logs')],
+        actions: ['s3:GetBucketAcl', 's3:PutBucketAcl'],
+      }),
+    )
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: ['arn:aws:s3:::' + Fn.importValue('wse-web-logs') + '/*'],
+        actions: ['s3:PutObject*'],
+      }),
+    )
+    // Allow creating and managing lambda with this stack name (needed for BucketDeployment construct)
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:' + serviceStackPrefix + '-*')],
+        actions: ['lambda:*'],
       }),
     )
     // Allow fetching details about and updating the application stack
@@ -97,6 +164,20 @@ export class UsurperBuildRole extends Role {
         ],
       }),
     )
+    // Allow creating DNS records in the domain stack's zone
+    if (props.createDns) {
+      this.addToPolicy(
+        new PolicyStatement({
+          resources: [
+            Fn.sub('arn:aws:route53:::hostedzone/${importedZone}', {
+              importedZone: Fn.importValue(`${props.domainStackName}:Zone`),
+            }),
+            'arn:aws:route53:::change/*',
+          ],
+          actions: ['route53:GetHostedZone', 'route53:ChangeResourceRecordSets', 'route53:GetChange'],
+        }),
+      )
+    }
     // Allow getting parameters for usurper in parameter store
     this.addToPolicy(
       new PolicyStatement({

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -1,0 +1,251 @@
+import codepipeline = require('@aws-cdk/aws-codepipeline')
+import {
+  CodeBuildAction,
+  GitHubSourceAction,
+  GitHubTrigger,
+  ManualApprovalAction,
+} from '@aws-cdk/aws-codepipeline-actions'
+import { AnyPrincipal, Effect, PolicyStatement, Role, ServicePrincipal } from '@aws-cdk/aws-iam'
+import { Bucket } from '@aws-cdk/aws-s3'
+import sns = require('@aws-cdk/aws-sns')
+import cdk = require('@aws-cdk/core')
+import { Fn, RemovalPolicy, SecretValue } from '@aws-cdk/core'
+import UsurperBuildProject from './usurper-build-project'
+
+export interface IUsurperPipelineStackProps extends cdk.StackProps {
+  readonly gitOwner: string
+  readonly gitTokenPath: string
+  readonly usurperRepository: string
+  readonly usurperBranch: string
+  readonly blueprintsRepository: string
+  readonly blueprintsBranch: string
+  readonly contact: string
+  readonly owner: string
+  readonly sentryTokenPath: string
+  readonly sentryOrg: string
+  readonly sentryProject: string
+}
+
+export class UsurperPipelineStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props: IUsurperPipelineStackProps) {
+    super(scope, id, props)
+
+    // S3 BUCKET FOR STORING ARTIFACTS
+    const artifactBucket = new Bucket(this, 'ArtifactBucket', {
+      removalPolicy: RemovalPolicy.DESTROY,
+    })
+    artifactBucket.addToResourcePolicy(
+      new PolicyStatement({
+        principals: [new AnyPrincipal()],
+        effect: Effect.DENY,
+        actions: ['s3:*'],
+        conditions: {
+          Bool: { 'aws:SecureTransport': false },
+        },
+        resources: [artifactBucket.bucketArn + '/*'],
+      }),
+    )
+
+    // IAM ROLES
+    const codepipelineRole = new Role(this, 'CodePipelineRole', {
+      assumedBy: new ServicePrincipal('codepipeline.amazonaws.com'),
+    })
+    const codebuildRole = new Role(this, 'CodeBuildTrustRole', {
+      assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
+    })
+    // Allow checking what policies are attached to this role
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [codebuildRole.roleArn],
+        actions: ['iam:GetRolePolicy'],
+      }),
+    )
+    // Allow modifying IAM roles related to our application
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:iam::${AWS::AccountId}:role/' + this.stackName + '-*')],
+        actions: [
+          'iam:GetRole',
+          'iam:CreateRole',
+          'iam:DeleteRole',
+          'iam:DeleteRolePolicy',
+          'iam:AttachRolePolicy',
+          'iam:DetachRolePolicy',
+          'iam:PutRolePolicy',
+          'iam:PassRole',
+        ],
+      }),
+    )
+    // Allow logging
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${AWS::StackName}-*'),
+        ],
+        actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+      }),
+    )
+    // Allow storing artifacts in S3 buckets
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [artifactBucket.bucketArn],
+        actions: ['s3:ListBucket', 's3:GetObject', 's3:PutObject'],
+      }),
+    )
+    // Allow fetching details about and updating the application stack
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/' + this.stackName + '-*/*')],
+        actions: [
+          'cloudformation:DescribeStacks',
+          'cloudformation:DescribeStackEvents',
+          'cloudformation:DescribeChangeSet',
+          'cloudformation:CreateChangeSet',
+          'cloudformation:ExecuteChangeSet',
+          'cloudformation:DeleteChangeSet',
+          'cloudformation:DeleteStack',
+          'cloudformation:GetTemplate',
+        ],
+      }),
+    )
+    // Allow reading some details about CDKToolkit stack so we can use the CDK CLI successfully from CodeBuild.
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [Fn.sub('arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/CDKToolkit/*')],
+        actions: ['cloudformation:DescribeStacks'],
+      }),
+    )
+    // Allow reading exports to get urls for other related services
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: ['*'],
+        actions: ['cloudformation:ListExports'],
+      }),
+    )
+    // Allow creating and modifying cloudfront
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: ['*'],
+        actions: [
+          'cloudfront:GetDistribution',
+          'cloudfront:CreateDistribution',
+          'cloudfront:UpdateDistribution',
+          'cloudfront:TagResource',
+          'cloudfront:CreateInvalidation',
+        ],
+      }),
+    )
+    // Allow getting parameters for usurper in parameter store
+    codebuildRole.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          // TODO: Remove dev and move prep to the prep version of the pipeline
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/dev/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/prep/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/test/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/usurper/prod/*'),
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/sentry/*'),
+        ],
+        actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+      }),
+    )
+
+    // CREATE PIPELINE
+    const pipeline = new codepipeline.Pipeline(this, 'UsurperPipeline', {
+      artifactBucket,
+      role: codepipelineRole,
+    })
+
+    // SOURCE CODE AND BLUEPRINTS
+    const appSourceArtifact = new codepipeline.Artifact('AppCode')
+    const appSourceAction = new GitHubSourceAction({
+      actionName: 'SourceAppCode',
+      owner: props.gitOwner,
+      repo: props.usurperRepository,
+      branch: props.usurperBranch,
+      oauthToken: SecretValue.secretsManager(props.gitTokenPath, { jsonField: 'oauth' }),
+      output: appSourceArtifact,
+      trigger: GitHubTrigger.WEBHOOK,
+    })
+    const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
+    const infraSourceAction = new GitHubSourceAction({
+      actionName: 'SourceInfraCode',
+      owner: props.gitOwner,
+      repo: props.blueprintsRepository,
+      branch: props.blueprintsBranch,
+      oauthToken: SecretValue.secretsManager(props.gitTokenPath, { jsonField: 'oauth' }),
+      output: infraSourceArtifact,
+      trigger: GitHubTrigger.NONE,
+    })
+    pipeline.addStage({
+      stageName: 'Source',
+      actions: [appSourceAction, infraSourceAction],
+    })
+
+    // MODIFY WEBHOOK SETTINGS... Not a super easy way to access these from cdk. Needs to be done after stage defined.
+    const sourceStage = pipeline.node.findChild('Source')
+    const sourceAppCode = sourceStage.node.findChild('SourceAppCode')
+    const webhook = sourceAppCode.node.findChild('WebhookResource') as codepipeline.CfnWebhook
+    // Only trigger on tag "ci" created. Must delete and re-create to move the tag and trigger pipeline.
+    webhook.addPropertyOverride('Filters', [
+      {
+        JsonPath: '$.ref',
+        MatchEquals: 'refs/tags/ci',
+      },
+      {
+        JsonPath: '$.before',
+        MatchEquals: '0000000000000000000000000000000000000000', // github sends this when a tag is created
+      },
+    ])
+
+    // DEPLOY TO TEST
+    const deployToTestProject = new UsurperBuildProject(this, 'UsurperTestBuildProject', {
+      ...props,
+      stage: 'test',
+      role: codebuildRole,
+    })
+    const deployToTestAction = new CodeBuildAction({
+      actionName: 'Build_and_Deploy',
+      project: deployToTestProject,
+      input: appSourceArtifact,
+      extraInputs: [infraSourceArtifact],
+      runOrder: 1,
+    })
+
+    // APPROVAL
+    const approvalTopic = new sns.Topic(this, 'PipelineApprovalTopic', {
+      displayName: 'PipelineApprovalTopic',
+    })
+    const manualApprovalAction = new ManualApprovalAction({
+      actionName: 'ManualApprovalOfTestEnvironment',
+      notificationTopic: approvalTopic,
+      additionalInformation: 'Approve or Reject this change after testing',
+      runOrder: 2,
+    })
+
+    // TEST STAGE
+    pipeline.addStage({
+      stageName: 'DeployToTest',
+      actions: [deployToTestAction, manualApprovalAction],
+    })
+
+    // DEPLOY TO PROD
+    const deployToProdProject = new UsurperBuildProject(this, 'UsurperProdBuildProject', {
+      ...props,
+      stage: 'prod',
+      role: codebuildRole,
+    })
+    const deployToProdAction = new CodeBuildAction({
+      actionName: 'Build_and_Deploy',
+      project: deployToProdProject,
+      input: appSourceArtifact,
+      extraInputs: [infraSourceArtifact],
+    })
+
+    // PROD STAGE
+    pipeline.addStage({
+      stageName: 'DeployToProd',
+      actions: [deployToProdAction],
+    })
+  }
+}

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -43,6 +43,8 @@ export class UsurperPipelineStack extends cdk.Stack {
     const codebuildRole = new UsurperBuildRole(this, 'CodeBuildTrustRole', {
       assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
       artifactBucket,
+      createDns: props.createDns,
+      domainStackName: props.domainStackName,
     })
 
     // CREATE PIPELINE

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -13,6 +13,8 @@ import ArtifactBucket from './artifact-bucket'
 import UsurperBuildProject from './usurper-build-project'
 import UsurperBuildRole from './usurper-build-role'
 
+const stages = ['test', 'prod']
+
 export interface IUsurperPipelineStackProps extends cdk.StackProps {
   readonly gitOwner: string
   readonly gitTokenPath: string
@@ -42,6 +44,7 @@ export class UsurperPipelineStack extends cdk.Stack {
     })
     const codebuildRole = new UsurperBuildRole(this, 'CodeBuildTrustRole', {
       assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
+      stages,
       artifactBucket,
       createDns: props.createDns,
       domainStackName: props.domainStackName,

--- a/src/usurper-prep-pipeline-stack.ts
+++ b/src/usurper-prep-pipeline-stack.ts
@@ -8,6 +8,8 @@ import UsurperBuildProject from './usurper-build-project'
 import UsurperBuildRole from './usurper-build-role'
 import { IUsurperPipelineStackProps } from './usurper-pipeline-stack'
 
+const stages = ['prep']
+
 export class UsurperPrepPipelineStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props: IUsurperPipelineStackProps) {
     super(scope, id, props)
@@ -21,6 +23,7 @@ export class UsurperPrepPipelineStack extends cdk.Stack {
     })
     const codebuildRole = new UsurperBuildRole(this, 'CodeBuildTrustRole', {
       assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
+      stages,
       artifactBucket,
       createDns: props.createDns,
       domainStackName: props.domainStackName,

--- a/src/usurper-prep-pipeline.ts
+++ b/src/usurper-prep-pipeline.ts
@@ -1,0 +1,78 @@
+import codepipeline = require('@aws-cdk/aws-codepipeline')
+import { CodeBuildAction, GitHubSourceAction, GitHubTrigger } from '@aws-cdk/aws-codepipeline-actions'
+import { Role, ServicePrincipal } from '@aws-cdk/aws-iam'
+import cdk = require('@aws-cdk/core')
+import { SecretValue } from '@aws-cdk/core'
+import ArtifactBucket from './artifact-bucket'
+import UsurperBuildProject from './usurper-build-project'
+import UsurperBuildRole from './usurper-build-role'
+import { IUsurperPipelineStackProps } from './usurper-pipeline-stack'
+
+export class UsurperPrepPipelineStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props: IUsurperPipelineStackProps) {
+    super(scope, id, props)
+
+    // S3 BUCKET FOR STORING ARTIFACTS
+    const artifactBucket = new ArtifactBucket(this, 'ArtifactBucket', {})
+
+    // IAM ROLES
+    const codepipelineRole = new Role(this, 'CodePipelineRole', {
+      assumedBy: new ServicePrincipal('codepipeline.amazonaws.com'),
+    })
+    const codebuildRole = new UsurperBuildRole(this, 'CodeBuildTrustRole', {
+      assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
+      artifactBucket,
+    })
+
+    // CREATE PIPELINE
+    const pipeline = new codepipeline.Pipeline(this, 'UsurperPrepPipeline', {
+      artifactBucket,
+      role: codepipelineRole,
+    })
+
+    // SOURCE CODE AND BLUEPRINTS
+    const appSourceArtifact = new codepipeline.Artifact('AppCode')
+    const appSourceAction = new GitHubSourceAction({
+      actionName: 'SourceAppCode',
+      owner: props.gitOwner,
+      repo: props.usurperRepository,
+      branch: 'prep',
+      oauthToken: SecretValue.secretsManager(props.gitTokenPath, { jsonField: 'oauth' }),
+      output: appSourceArtifact,
+      trigger: GitHubTrigger.WEBHOOK,
+    })
+    const infraSourceArtifact = new codepipeline.Artifact('InfraCode')
+    const infraSourceAction = new GitHubSourceAction({
+      actionName: 'SourceInfraCode',
+      owner: props.gitOwner,
+      repo: props.blueprintsRepository,
+      branch: props.blueprintsBranch,
+      oauthToken: SecretValue.secretsManager(props.gitTokenPath, { jsonField: 'oauth' }),
+      output: infraSourceArtifact,
+      trigger: GitHubTrigger.NONE,
+    })
+    pipeline.addStage({
+      stageName: 'Source',
+      actions: [appSourceAction, infraSourceAction],
+    })
+
+    // DEPLOY TO PREP
+    const deployToPrepProject = new UsurperBuildProject(this, 'UsurperPrepBuildProject', {
+      ...props,
+      stage: 'prep',
+      role: codebuildRole,
+    })
+    const deployToPrepAction = new CodeBuildAction({
+      actionName: 'Build_and_Deploy',
+      project: deployToPrepProject,
+      input: appSourceArtifact,
+      extraInputs: [infraSourceArtifact],
+    })
+
+    // DEPLOY STAGE
+    pipeline.addStage({
+      stageName: 'Deploy',
+      actions: [deployToPrepAction],
+    })
+  }
+}

--- a/src/usurper-prep-pipeline.ts
+++ b/src/usurper-prep-pipeline.ts
@@ -22,6 +22,8 @@ export class UsurperPrepPipelineStack extends cdk.Stack {
     const codebuildRole = new UsurperBuildRole(this, 'CodeBuildTrustRole', {
       assumedBy: new ServicePrincipal('codebuild.amazonaws.com'),
       artifactBucket,
+      createDns: props.createDns,
+      domainStackName: props.domainStackName,
     })
 
     // CREATE PIPELINE

--- a/src/usurper-stack.ts
+++ b/src/usurper-stack.ts
@@ -120,7 +120,6 @@ export class UsurperStack extends cdk.Stack {
 
     // Create DNS record (conditionally)
     if (props.createDns) {
-      // tslint:disable-next-line:no-unused-expression
       new CnameRecord(this, 'ServiceCNAME', {
         recordName: props.hostnamePrefix,
         domainName: cloudFront.domainName,
@@ -132,13 +131,11 @@ export class UsurperStack extends cdk.Stack {
       })
     }
 
-    // tslint:disable-next-line:no-unused-expression
     new CfnOutput(this, 'WebsiteCNAME', {
       value: cloudFront.domainName,
       description: 'Website CNAME target',
     })
 
-    // tslint:disable-next-line:no-unused-expression
     new CfnOutput(this, 'WebsiteBucketName', {
       value: bucket.bucketName,
       description: 'Name of S3 bucket to hold website content',
@@ -146,7 +143,6 @@ export class UsurperStack extends cdk.Stack {
 
     // NOTE: If you deploy directly from blueprints, it will use whatever build happens to be sitting at the build path.
     // It will NOT be rebuilt. To build and deploy, use usurper/scripts/codebuild/local.sh
-    // tslint:disable-next-line:no-unused-expression
     new BucketDeployment(this, 'DeployWebsite', {
       sources: [Source.asset(props.buildPath)],
       destinationBucket: bucket,

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": ["tslint:recommended", "tslint-config-prettier"],
   "rules": {
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "no-unused-expression": [true, "allow-new"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,519 +2,521 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assert@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.9.0.tgz#52cf0cf0909ba7272b61e5b1c8c36055433177ab"
-  integrity sha512-5Z2X/pd48/chUAX6fBmK0l01wlCT+IUXfTAElZS/z3jNVYp4w6KcrtyAhHMwxoqG6RVoAqSyyM8GwpQAHKzNLA==
+"@aws-cdk/assert@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assert/-/assert-1.12.0.tgz#36dd4d136674672ac4f4e9eadedb752345ce04d0"
+  integrity sha512-q4FTHJl4uQxk8/vp9sf7D47QqICl4GhxdwIsnClk8HK1sJoCVfpfquhvcPtco6EtHl2j1yHX6T1Q2xhn1LkTvg==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/cloudformation-diff" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
     jest "^24.9.0"
     source-map-support "^0.5.13"
 
-"@aws-cdk/assets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.9.0.tgz#ba363c04a802a6bf483f4286948190bcc7bd8e87"
-  integrity sha512-3FC1BCpTJaHRbRuBQs83qPoX3kFBG7t7qWuEAX2W9XjQDSfbutqCMsheSjfcoX5FXuMNhZEG6PXawp2dLJGjvQ==
+"@aws-cdk/assets@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.12.0.tgz#ca2a5581411dde142be3711384359bcc6e639e84"
+  integrity sha512-8dEL6nEfwU4UANauoQnNpGflME5AujHGXBKEe4UEPDNgHbRD9UzVDSYH871KuTb151rdXvIoV7bzO5m77yrqLw==
   dependencies:
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-apigateway@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.9.0.tgz#0f0d1b83d3e1b01edba6b965dadd8b71d04d519a"
-  integrity sha512-Oj2uLoPw0MMhF2s1/OcnPTdvTnKwFL+wocxu9i3ZxYC13E5Jcsj3xpy0YzpRQZQoCY8dSrshR1tnw+2j1fVRbg==
+"@aws-cdk/aws-apigateway@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.12.0.tgz#eae046a850001345d68a008fae79a7675f5c9dfe"
+  integrity sha512-6t3FvHHt5EB14L8sRSqyM/SdKmu9MrYltw9Uk5yM01td8h42OmiDku32GrHeMY0Tt2g9fgjlNy1m8hmt2/nerQ==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-certificatemanager" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-applicationautoscaling@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.9.0.tgz#654e3f986fc37ad16185ab1cb0308475d754ffc9"
-  integrity sha512-LsHfJcLO1q7avF0KOpqhNeLMKDkr6Bt8FeW/Jcx8wFhoy6TylFTbNDpoYgujt6PTr1V1kmIEM4weDkiD8GqA4g==
+"@aws-cdk/aws-applicationautoscaling@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.12.0.tgz#274ae8cd094cea69a076081c13332bdc747ba4c5"
+  integrity sha512-pbTpTW1N7etzDm2mH/djvO1h8zPEMTsjXs962hKqjnFtba2G9CFv8VH4PqKVHMrAy+zT1oWDwhVkEySzjNmQsw==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "^1.9.0"
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-autoscaling-common" "^1.12.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-autoscaling-common@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.9.0.tgz#91001429c6dcddcdbb1c8ac48f49cb7e5c1d1136"
-  integrity sha512-dfZgCZKf83B+ZSPGiTvfPVUGWAvDOGXJUmKl5fj8efA6+8mJgPAoYNnGtCxMzCvcUhe84wASTC2gYNXRJd8fzw==
+"@aws-cdk/aws-autoscaling-common@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.12.0.tgz#fd18c01fac754413c949004bd5faaede27d16689"
+  integrity sha512-VsU4Gx1Y6vPaeNP+17Bq8aJB1De8Q75utP55XHnxm67oC74TJXfEMYgzPgSX3vQS1aBMB1pgk5mUo/4xl7pvsA==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-autoscaling-hooktargets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.9.0.tgz#aa91937afd042c85943c284529d248624775513d"
-  integrity sha512-T7AhBe+PypS0qEgjs9axSpqHD9jsjARW/nNOPC0ba9Q0xebETvNgjkDPsjKazCTzx8pTXqd3/MCSvgxiTyWyvQ==
+"@aws-cdk/aws-autoscaling-hooktargets@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.12.0.tgz#222a10d9551f4d50a25f585fc3fabc48382fd559"
+  integrity sha512-seAjLhXZdr6X8ZvNbWnUXRABE1qey1JaDZ3+6W6B80RpsYsEO9gL5NaZjMeDBM9gSPkfQSCzw7tZzh91ecrxbw==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/aws-sns-subscriptions" "^1.9.0"
-    "@aws-cdk/aws-sqs" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-autoscaling" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/aws-sns-subscriptions" "^1.12.0"
+    "@aws-cdk/aws-sqs" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-autoscaling@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.9.0.tgz#0a9877feb78247825745fa5c89fc7bb0cb862379"
-  integrity sha512-Uxta9hFD5TOD8GA3lvyxpEvd5+SCjYJfd86BYQGqMUU9ijMAc+cBL1TtO1ZCn2PDaZMfMwtweTBBLdlxYt7Tow==
+"@aws-cdk/aws-autoscaling@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.12.0.tgz#d8cecf39ac2e26e863d8b98e67834b8652593f6c"
+  integrity sha512-BLfNp6c4NnCffkEeaq9ymV+rU5z4Sjk4wxiM3TtaM71CuNZvwosFivVJXUCoOYp4ew+YO/oRn8vk75o4wFWCNw==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "^1.9.0"
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancing" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-autoscaling-common" "^1.12.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancing" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-certificatemanager@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.9.0.tgz#1545278940033a8866683bd2d4f25be8312658ac"
-  integrity sha512-HyZS5I2zb8mcLrzcveFGqdsLynErOeAvAYt+WD6r8R8qjtt53AsIOVVvi1RNFbSSSUPoqxadyuy/n22Va44+sA==
+"@aws-cdk/aws-certificatemanager@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.12.0.tgz#7133219a835d81e6a7f308ace114bc5b04ea61c4"
+  integrity sha512-imjEmPjVLtNsiPEXx3i3oLDxdkEUNOmnllL0QkXOwPthTy8l9GQhfa3GE8NGpsy7QBtr7vBrhc6qsKB5FMRFYw==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-route53" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudformation" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-route53" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-cloudformation@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.9.0.tgz#d492648dedae31144daa154f1debaf28db3a4b26"
-  integrity sha512-g4EIZkPjakN+ipOSzbt73iRUCEHLQwKiLdIb9zS3520aBgiAEOZ6NcDkq0/740hVItjOiRr8+J0oCtRdpm0sGA==
+"@aws-cdk/aws-cloudformation@^1.11.0", "@aws-cdk/aws-cloudformation@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.12.0.tgz#b559bda5fe0c09e3f234960579e97ab825c8b54e"
+  integrity sha512-DY8oeVyTuwC9fkJK/VMTY0VSNymMrWsq0D7A3eRtKAMDO2bKkrRo5BSzkCIqmOgZayGTO8Iuvl1k6ESeN5AYew==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-cloudfront@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.9.0.tgz#66c67c00dfca33d53fc400c4a462a439dffb53af"
-  integrity sha512-nUierksPZWguB6QITb9iY/Q/qeYaP5ZZSycFj8k/iLTGz86+QAVFehk7myZdt6JGnUdtVxURPDYY07g9zSkItw==
+"@aws-cdk/aws-cloudfront@^1.11.0", "@aws-cdk/aws-cloudfront@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.12.0.tgz#b2cd04915e67cc35431741004ca4eb0da4eed14b"
+  integrity sha512-ef1z+x4e0peUJNoYv0HgnzxRnrerpKJqsIvToK/ELC2AruJu8R/BKe1X+8eAWhzzjhYkTj9DIZipLlbaQ0rb3Q==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-kms" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-certificatemanager" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-kms" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-cloudwatch@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.9.0.tgz#1a59dee00341d39c1ac652100a60966d34ccd56c"
-  integrity sha512-+Bl4CHN+Ct30qcbgMNScJ7P6aM2ZUh2CXhpbsrinlxj7s2ukp1YzXoKHX6GDUx3ATvHiAwZogIwJEOMuf7Nkjw==
+"@aws-cdk/aws-cloudwatch@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.12.0.tgz#7960271f0bf32f206a23e9e6b296b1a80151fa03"
+  integrity sha512-GUlsa5/qqafbNXb2xbQs52nmYme/hjCydlOJAHXjhdvnq4pJ8f6/axtpq8Icfkg4UT5SG1d8jcl7WMT0e1Lmdg==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-codebuild@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.9.0.tgz#a907cd5821d119c14ba8ac8b0a1d7c6affc8b308"
-  integrity sha512-ci3JhQDfLirRic5SIbGlXwrXspa/6CT+2eJUDg1bK55ep86oTLH7mQlH3JlxlIf+ks/92JmWZjU6gVVZSaTHsA==
+"@aws-cdk/aws-codebuild@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codebuild/-/aws-codebuild-1.12.0.tgz#f6a9826166bfc19ac1dcf23a30412f8179ac0a85"
+  integrity sha512-BDEXAAuJXdCy2QNBCPmihZBbBs1JSz3O0eX8povFKLUa47RqfZilJ9DSLf76LbUoTqHQM1wwk146Q6ByRhcF+Q==
   dependencies:
-    "@aws-cdk/assets" "^1.9.0"
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-codecommit" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-ecr" "^1.9.0"
-    "@aws-cdk/aws-ecr-assets" "^1.9.0"
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-kms" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/aws-s3-assets" "^1.9.0"
-    "@aws-cdk/aws-secretsmanager" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/assets" "^1.12.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-codecommit" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-ecr" "^1.12.0"
+    "@aws-cdk/aws-ecr-assets" "^1.12.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-kms" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/aws-s3-assets" "^1.12.0"
+    "@aws-cdk/aws-secretsmanager" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-codecommit@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.9.0.tgz#343b827ad979b449b03930114590830d9282f43b"
-  integrity sha512-YG0CI9LVr+YoxrUMqtMu/ouv4jfbVGaKZOlLfIsxLDmHWiBU7emIn40UiV8qrirsnJDk9qX84lZB3IajHt49Uw==
+"@aws-cdk/aws-codecommit@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codecommit/-/aws-codecommit-1.12.0.tgz#3a6f2d66d85edc6c7114773e647527247ca99ed2"
+  integrity sha512-L+TAfTS2yYvcmIxbnXxLOamvZevtGPoms6t4WI2IXJci9HpLCw6hXJNZfR8bBBN6b6lNuGw49M3lT9tsoDw0KQ==
   dependencies:
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-codedeploy@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.9.0.tgz#1fc86c57abbf342fec202bd2fc92be7781abbbd0"
-  integrity sha512-RJW5ZkSv+/wo3vFTtexQ7Uvdx418EyEdOzZHoZ1ymxZR3NmnUFPxgKOJcnUu+6LShbpCW8Q9g5DNcXMtIviJdQ==
+"@aws-cdk/aws-codedeploy@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codedeploy/-/aws-codedeploy-1.12.0.tgz#ffb655a3b49529b756be004b253f039ff5fc486f"
+  integrity sha512-+SEtY3fDVCld5ETNDLNWgUpS1uvAiMLMtcH1EGksNZPkfacZX2Mlm4PTA2BzLhJSoW2Xik9D2p1kJz91dlTMag==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "^1.9.0"
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancing" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-autoscaling" "^1.12.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancing" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-codepipeline-actions@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline-actions/-/aws-codepipeline-actions-1.9.0.tgz#574f104e0bfffbc7a65882e9d5a3149164b1478a"
-  integrity sha512-Z0+EVwkigk0lme3CUvsE1e1HiBjBBjNAnX0c/VO+96Ti1NO+D968VPU6HZspAk26GLth8OUzQJBSFspzPbDfSQ==
+"@aws-cdk/aws-codepipeline-actions@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline-actions/-/aws-codepipeline-actions-1.12.0.tgz#7288238851b309dd159a1076bacc59c5e11d74d6"
+  integrity sha512-BcRK1IZO414GEa3MM7Q2ganYuePbKPDeADb8Wm1JSbR7Nj0C5QQdi7j58f+Hpzb8TUim1Q352fdoaRLE0cSQZA==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "^1.9.0"
-    "@aws-cdk/aws-codebuild" "^1.9.0"
-    "@aws-cdk/aws-codecommit" "^1.9.0"
-    "@aws-cdk/aws-codedeploy" "^1.9.0"
-    "@aws-cdk/aws-codepipeline" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-ecr" "^1.9.0"
-    "@aws-cdk/aws-ecs" "^1.9.0"
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-events-targets" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/aws-sns-subscriptions" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudformation" "^1.12.0"
+    "@aws-cdk/aws-codebuild" "^1.12.0"
+    "@aws-cdk/aws-codecommit" "^1.12.0"
+    "@aws-cdk/aws-codedeploy" "^1.12.0"
+    "@aws-cdk/aws-codepipeline" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-ecr" "^1.12.0"
+    "@aws-cdk/aws-ecs" "^1.12.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-events-targets" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/aws-sns-subscriptions" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-codepipeline@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.9.0.tgz#a49da7351234713bcbc04e58ecb60e299973962a"
-  integrity sha512-Svx1MfCe/+wZTL53w9jiIuVCKT0QsglJV3eHd7a58Fuf2QzWNKHwr3PcgGIHnBTHjh2f9Qc/+ey6npk+fzW0BQ==
+"@aws-cdk/aws-codepipeline@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-codepipeline/-/aws-codepipeline-1.12.0.tgz#783e30e8f86d802d56f24cf80233f21ec1ee9d79"
+  integrity sha512-R858h5usHfve2QROotdTNTxplvMjH4hvLbyKKVnG0n7Ko77PJioOVIuRSXxNPrBMFh7oxs7TmRKwfBcJFKiP9g==
   dependencies:
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-kms" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-kms" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-ec2@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.9.0.tgz#bffd6390856171114758344d49129fdf901db113"
-  integrity sha512-6noSzLDisNrp4Ad4k+BWiCxLWBAe1skGtzs0TsvxWxXIseXvLmRnlgXqyslmTCDHW9v0chTLdKgQXlTq4Zj8EA==
+"@aws-cdk/aws-ec2@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.12.0.tgz#0c5cf8a68ca6e648bc48a290d6a54a18705caeba"
+  integrity sha512-kmQKlQ6AOdK2PVPcgK0fqRr4qpvxmW6jZbHjzylIEYRwi1FbOMTEh0zVpguuB0i+hl8AHgdWMF0v13g25Lg82g==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-ssm" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-ssm" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-ecr-assets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.9.0.tgz#634987c463a3fa19cab866c0586077780896a89c"
-  integrity sha512-1AvzXFLKWVvo2QTsk7Xi0M73fPJllUKjqm2/XhekJ2CQaAiHReHrhYt7KfXhhoFRBYo+jG7OfgVM9oLoAT7+0g==
+"@aws-cdk/aws-ecr-assets@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.12.0.tgz#b18b5b2f02f19b6ffbfde1d5a5e3e0a4abbf3aed"
+  integrity sha512-jDXITloOzKyA8VNqcVaD1XeRFWE/CKX9OzwJ96FF5t2OZHpHKaxwuoBcwQHmKyA+556NWFtr4foRDixD7WAJ1Q==
   dependencies:
-    "@aws-cdk/assets" "^1.9.0"
-    "@aws-cdk/aws-cloudformation" "^1.9.0"
-    "@aws-cdk/aws-ecr" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/assets" "^1.12.0"
+    "@aws-cdk/aws-cloudformation" "^1.12.0"
+    "@aws-cdk/aws-ecr" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-ecr@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.9.0.tgz#c450b2a74cb7e6c0e11185a04ef213dbc641ba80"
-  integrity sha512-ZRgbi2GUAkKSbRmnHhqXw/tXNCeWQf6y6VhFCMpFGpilMqv/ArE6xYBPfboeegWhv/OpGt+lEXGOKwbefvbUrw==
+"@aws-cdk/aws-ecr@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.12.0.tgz#1e897555c0c2c66d54a9cb6703927ae33237d88e"
+  integrity sha512-Uh4yBWW7OSLsXZfzORDy2DhQaWzTjmcv911FqoCj/ERIbXxmZ/NQF87lUfu/wT44u/RPhcT+Yv5axeb0M6TFVA==
   dependencies:
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-ecs@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.9.0.tgz#036d8f7225ee8681f50784dfbbeb830b296b113e"
-  integrity sha512-3REW8eUzVL+8/+M5NBcWodGPGcrjvnDVYWmKLZkKm1vMlti9/0jAENF6wjxHGxJg7ZWyhUrvs1MfUgqWSslecg==
+"@aws-cdk/aws-ecs@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.12.0.tgz#659a77c226dbedd5f3d37c26b776c67fa0f4c195"
+  integrity sha512-Z9OzGht6BCZq8+ojCwlbXcLt3obbFHaZE6Rg/EO/2dIaDgY8BdBk/wEdcgrgPBExwUd8QMOoiVHAyk+Z5DPIVg==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "^1.9.0"
-    "@aws-cdk/aws-autoscaling" "^1.9.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "^1.9.0"
-    "@aws-cdk/aws-certificatemanager" "^1.9.0"
-    "@aws-cdk/aws-cloudformation" "^1.9.0"
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-ecr" "^1.9.0"
-    "@aws-cdk/aws-ecr-assets" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancing" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-logs" "^1.9.0"
-    "@aws-cdk/aws-route53" "^1.9.0"
-    "@aws-cdk/aws-route53-targets" "^1.9.0"
-    "@aws-cdk/aws-secretsmanager" "^1.9.0"
-    "@aws-cdk/aws-servicediscovery" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/aws-sqs" "^1.9.0"
-    "@aws-cdk/aws-ssm" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/aws-applicationautoscaling" "^1.12.0"
+    "@aws-cdk/aws-autoscaling" "^1.12.0"
+    "@aws-cdk/aws-autoscaling-hooktargets" "^1.12.0"
+    "@aws-cdk/aws-certificatemanager" "^1.12.0"
+    "@aws-cdk/aws-cloudformation" "^1.12.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-ecr" "^1.12.0"
+    "@aws-cdk/aws-ecr-assets" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancing" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-logs" "^1.12.0"
+    "@aws-cdk/aws-route53" "^1.12.0"
+    "@aws-cdk/aws-route53-targets" "^1.12.0"
+    "@aws-cdk/aws-secretsmanager" "^1.12.0"
+    "@aws-cdk/aws-servicediscovery" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/aws-sqs" "^1.12.0"
+    "@aws-cdk/aws-ssm" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-elasticloadbalancing@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.9.0.tgz#458e86077a6fd39670fc248ad33a345fb67c736e"
-  integrity sha512-oHLDXyLhpdi2l63+jlUjtkNlt9XaxGGs3glp43tOz5uYSnFqJgxWdHaoLPwUpBNqMVLE9cQbQ+ckEGENeOEgbw==
+"@aws-cdk/aws-elasticloadbalancing@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.12.0.tgz#b9f13845b801da8c5916efa11f6b6b74d8998b1d"
+  integrity sha512-x/UggO5ACO9bzs2iynEmoJXM2xsVd4Utk+hni7NBHs3dqp1bNfmyqt1gdu4sFK8IdaOI+W8Cx+Eq6QlcE+RqUg==
   dependencies:
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-elasticloadbalancingv2@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.9.0.tgz#19f920266d20f2ce3ff1cb11fd94761bda8753f7"
-  integrity sha512-9ocZAQmxyc1OfnH330vFWWYOuVbdBdd/vitBcF4Lz3P8hYNagUs+ZEW29CzGOHo+WnLX0no4I2sxnfOBvLc5dg==
+"@aws-cdk/aws-elasticloadbalancingv2@^1.12.0", "@aws-cdk/aws-elasticloadbalancingv2@^1.9.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.12.0.tgz#9524dd9a6b6f359084927920345dd0892eaa9b18"
+  integrity sha512-V7LIulTMBEShEnY/uHKQKz0Nk6igsu65Xkj26O0hPwJ3VQ9HtX18YsAUuuejm42LKrs2dwJufa0qiUfw9IIS3A==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "^1.9.0"
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-certificatemanager" "^1.12.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-events-targets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.9.0.tgz#8295ef30a3592172965b677bfa7a997f5616920e"
-  integrity sha512-lThLOvO7cXyl8VoRP7X7ZW2dsjQ/TkVND0FMCKnUJMRjD1ec9ljV2Xb4RDwM38lxrrlvegUeAarEEBkiE0pcUw==
+"@aws-cdk/aws-events-targets@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events-targets/-/aws-events-targets-1.12.0.tgz#16dd1d3d9089a20e90a256628ea85e05e8dd23c5"
+  integrity sha512-X+cFkNXUNRZBqvnfpmqdAf7DMpIZhVtR+a2tF+Khql1b2//DIgGk43nMThywSnP0fb8hgDlCKW8BUQRlAqV1GQ==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "^1.9.0"
-    "@aws-cdk/aws-codebuild" "^1.9.0"
-    "@aws-cdk/aws-codepipeline" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-ecs" "^1.9.0"
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/aws-sns-subscriptions" "^1.9.0"
-    "@aws-cdk/aws-sqs" "^1.9.0"
-    "@aws-cdk/aws-stepfunctions" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudformation" "^1.12.0"
+    "@aws-cdk/aws-codebuild" "^1.12.0"
+    "@aws-cdk/aws-codepipeline" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-ecs" "^1.12.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/aws-sns-subscriptions" "^1.12.0"
+    "@aws-cdk/aws-sqs" "^1.12.0"
+    "@aws-cdk/aws-stepfunctions" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-events@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.9.0.tgz#ed154a67662f2397e2935122651a5d8b13789e31"
-  integrity sha512-xIZQDkwtj8KyzDhC2Lcjn6Ac7d4E//W7Lfl7m/iXAsPrclkZBODPJhtzytX7PGM++hJy6hKspbtNxnGGbDflkg==
+"@aws-cdk/aws-events@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.12.0.tgz#fe3d1e7f9707105fe0fbeae15f2402227cb20367"
+  integrity sha512-xIc/qKhX5NvXF01MDuB6fLm26j1fHRSLWx2sk0if+gv/unAcMw3uK0z3UGhShf2YaJysewnrEPJ9fsBD6HOIww==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-iam@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.9.0.tgz#ffc7b23e761fea76fca373cceb0c976fab6af7d1"
-  integrity sha512-wCnSgdM4Jxbzzjypng7z+vzH+uAHFBZrBH56ck1xG7rin+wJZFdC4vaAMD39nVf5V1EUEAuwQjK0F33QuT44iQ==
+"@aws-cdk/aws-iam@^1.11.0", "@aws-cdk/aws-iam@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.12.0.tgz#1b449ac58cdf11d8fe7ceca5de162e83150db4fe"
+  integrity sha512-fXtEhMek08wbwpIeQcglmM8NwhqdxHsQCNJAK2HfmZPdvXmUom+UYZoaQaZHyKnYt1Ou6daZOsU6JtIGGfjLiQ==
   dependencies:
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/region-info" "^1.9.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/region-info" "^1.12.0"
 
-"@aws-cdk/aws-kms@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.9.0.tgz#9f0b710d27732d5be77221b62493fe045f084901"
-  integrity sha512-U4ucUl7zT5jML/FkWNd74lVqzi3cC9tkt7j7pORWUp3ssspQ5G8QcwuDtFxGBarsx6gI9QjwcqyoHPHrXotlHQ==
+"@aws-cdk/aws-kms@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.12.0.tgz#9f7cc7c584c00cfde048895b3e9c4a2a0b2982bc"
+  integrity sha512-fhO73MiZDUfpvA3E9+AlwYRLS/lFvmfwyWRBwVuXKTTNk0XPegZjhfLK5wHkJkRmK+ewj3ovfYPmC9L1QxARZw==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-lambda@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.9.0.tgz#283495a41d9f51633bd5971c07562aa541956b9b"
-  integrity sha512-Daf9Sy/Xr2NoXnHf1xn/rWdZRd6rN3RgBza1g2kVX5/D3QavHYSsBMEsbgb9EdrbakBpDMPyO7Q8v1SWF5+slQ==
+"@aws-cdk/aws-lambda@^1.11.0", "@aws-cdk/aws-lambda@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.12.0.tgz#26376edca498a0ff6f344cc9083f3bf5c4a187c0"
+  integrity sha512-lQw/bpVomz1JB4UcdXtulBujicVUViAR2HcqwkJw54Vm4f6OaHA4KedwebOsiu5ZjfzhGqpqIrhNtIT08ZPF6g==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-logs" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/aws-s3-assets" "^1.9.0"
-    "@aws-cdk/aws-sqs" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-logs" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/aws-s3-assets" "^1.12.0"
+    "@aws-cdk/aws-sqs" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-logs@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.9.0.tgz#890b7093cc88e399278f20d10ca047125a9e6e49"
-  integrity sha512-MkFfw1LsMv+IMN455ADbRBsogCH8gtU41l201RifNfDT2TZOQUaW7VHtODIu34ZxWR+Qzd04cAcHXTJ0giLA3A==
+"@aws-cdk/aws-logs@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.12.0.tgz#31ea76924629540a9811b73e8fd60c7b5f9380c2"
+  integrity sha512-++Mr/WtENAMgEzGyRO9xm74ULZxXzbAIE1FzMg7SdI0weUWN8rcHhfplSsNPcMQLt+nDGq42G/8QwvgB18sg1A==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-route53-targets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.9.0.tgz#5188fd20929dfb07ce95eb4a519e3dbc560ea3cb"
-  integrity sha512-EIfz9GOfOxLyPRjvn+VpHAS0BnFIZA7X61YVNxFAV5xhoWf3kkAKenI9SvNt3TuucQhOEEWeGV4WLymZdQFN1w==
+"@aws-cdk/aws-route53-targets@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.12.0.tgz#f55aae864658572343bc00982cd5a6fce512799c"
+  integrity sha512-iYMXeK5pGCbmELwYFignSEDyV4PUjWKKUb7RMZiv9DCoOTL6Ud7/AsKborGzuJJ9Jcjzs3m6HTYHkSuTJyccgQ==
   dependencies:
-    "@aws-cdk/aws-apigateway" "^1.9.0"
-    "@aws-cdk/aws-cloudfront" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancing" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-route53" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/region-info" "^1.9.0"
+    "@aws-cdk/aws-apigateway" "^1.12.0"
+    "@aws-cdk/aws-cloudfront" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancing" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-route53" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/region-info" "^1.12.0"
 
-"@aws-cdk/aws-route53@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.9.0.tgz#a7583ff20d4d018317fd15050b29d06314d8eca8"
-  integrity sha512-+qhPM1UCht9674/xx1zLyjA4sXy1lEG/14W47VyC3+u9nLydrvqHFlVO470q05mcRP04C4RhfaVumFQpO0D7yQ==
+"@aws-cdk/aws-route53@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.12.0.tgz#add0e0490239205e963a2e755e923f8624257b4d"
+  integrity sha512-DqlU60KpQCMhJypGaKvqpC+DET9clTl7PJLqWv8yfvJbTGMlH4Pf1Iv/kn8uiSTimq5FnFLohpXs1rD6WUO4hA==
   dependencies:
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-logs" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-logs" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-s3-assets@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.9.0.tgz#17d5dc89dced9da1beb0cd43e3f5cef4ce4a5aed"
-  integrity sha512-fuguSw8lxNtOK9agJ7He8ulVRIGASnUhltEWzJiZqMc/72X3D9MTJuLnwEZwKaKm7qlgy8wfCHXZ/e0FxWasRw==
+"@aws-cdk/aws-s3-assets@^1.11.0", "@aws-cdk/aws-s3-assets@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.12.0.tgz#7d57498e6fa0bc37a92f82427f3d6a392333a3af"
+  integrity sha512-qR4arr8Dqbsb7NpMDHv/wtMkJTW5Ovru4bCxCz9+wzYbiTpem1QFGLFKJb/5EnDqzKYzw2MtjHEIMdUmo608Gw==
   dependencies:
-    "@aws-cdk/assets" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/assets" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-s3" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-s3-deployment@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.9.0.tgz#066aeb862305b817a34d813b8969dbefb5813f7b"
-  integrity sha512-9BwW3Yvv6po9FcPh+PVar1k+fY24JVE5W3L1AKPqF7FjAor3Uvwzdn5xcfQyp7KOk+IVpJb2yo222GLueuAjFQ==
+"@aws-cdk/aws-s3-deployment@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-deployment/-/aws-s3-deployment-1.11.0.tgz#c5a4b23f29b46447a4f3e68215d2291587b203d5"
+  integrity sha512-KGHUXoQmpfpQe2Uvdj1UG1CPQzez4qbVNYlrkgO9vgC/CVRMh7ggmCZ3YOt2r3qC5FJ0LZT2nL0pjXRw5G4pcg==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "^1.9.0"
-    "@aws-cdk/aws-cloudfront" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-s3" "^1.9.0"
-    "@aws-cdk/aws-s3-assets" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudformation" "^1.11.0"
+    "@aws-cdk/aws-cloudfront" "^1.11.0"
+    "@aws-cdk/aws-iam" "^1.11.0"
+    "@aws-cdk/aws-lambda" "^1.11.0"
+    "@aws-cdk/aws-s3" "^1.11.0"
+    "@aws-cdk/aws-s3-assets" "^1.11.0"
+    "@aws-cdk/core" "^1.11.0"
 
-"@aws-cdk/aws-s3@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.9.0.tgz#652d3157673255ef981fae0ac8e38ee83dd4c5ea"
-  integrity sha512-DeOlW2x0kqgVBuZa0Conmt5+zWFvfw6xqQbsU81+G9efgI8cBOVHpCyTYknrhgECbM/2pB+qERsaLyTFqQ5+qw==
+"@aws-cdk/aws-s3@^1.11.0", "@aws-cdk/aws-s3@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.12.0.tgz#88229f795351d57eba5d6dfcf15b8bca23780bb0"
+  integrity sha512-AdImGtShC3shHFGtg7DBzauYnOBr3mL0WiI9o69IijBu3+lfUpePYqxr0cBHHxXhAVTrGADdAo/RyPvdbNd1Iw==
   dependencies:
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-kms" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-kms" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-secretsmanager@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.9.0.tgz#38911976f3def66d5c32dc4ca3107e16313a273f"
-  integrity sha512-V8n9JO3AKGukYyyma/8BUS2cOr+WOR6TyhFWrK3MO5ne2wLLeoIyPqqsLXIQnNQehV8bSu9vjNXQYJfVT3x5fQ==
+"@aws-cdk/aws-secretsmanager@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.12.0.tgz#1b502812e58bc7ed3941976b388bdd8a151a60a7"
+  integrity sha512-+OhFhAEJc+3AI2sPJM+tA/i6yu0hkuwyOAuBc0VV94RCcja5vD/vUh1/w6M/4FDCnhJA0xc4RKDNYfPFCGog1Q==
   dependencies:
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-kms" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-kms" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-servicediscovery@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.9.0.tgz#65f08925de7388a7fd239e106a2b2b043c5ce33a"
-  integrity sha512-TCB9i61Qm5Us71e0Sceu9uh5pTYRnqQkCQuNQlTxdY+jqBcFgV4PIAgPyflkTeGJKKA+qDhdDLBvwK3e+D/PnQ==
+"@aws-cdk/aws-servicediscovery@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.12.0.tgz#1a97bd3db4e455bddc22106cc26a3f388652421b"
+  integrity sha512-ybIKOlDNkjQhX63tOWiuc577qt20Y7QUcfYeE/Vg0CIevtGnS15TfT0GuTrjMVY9hKvsWwGRm2iM3ezgGqd9yQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "^1.9.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
-    "@aws-cdk/aws-route53" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-ec2" "^1.12.0"
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.12.0"
+    "@aws-cdk/aws-route53" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-sns-subscriptions@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.9.0.tgz#0f46acd1372d26ad35a249c8cf71b59563bf76eb"
-  integrity sha512-1IMT+0hpUOF9hJxVds9HM4NOmyDxasvZ8TvbvOx5FzwuHGoZX44/JnhXK/WcoQCj6lM1m5NEOsno9CNXaRj4nw==
+"@aws-cdk/aws-sns-subscriptions@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.12.0.tgz#d50c701732e491f4c61605c7a6e07889c653e808"
+  integrity sha512-SobNvKB4k1IRaAmV9IYWJelo0esR5i4CC69d453yUh3zQUJItF9xSUxPxNfrTVYi6zPqPdG2bnfyMAPHQWxNdw==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-lambda" "^1.9.0"
-    "@aws-cdk/aws-sns" "^1.9.0"
-    "@aws-cdk/aws-sqs" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-lambda" "^1.12.0"
+    "@aws-cdk/aws-sns" "^1.12.0"
+    "@aws-cdk/aws-sqs" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-sns@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.9.0.tgz#74fc9552629d31558960a19d89d62a8681cde0ad"
-  integrity sha512-c75L/yNJ3QSl16+LvMzuK61eSXSltM0mu4xG521ZBCnasc6l7Ioqt0FaAHqFEqEH+DXjio9r3h1pviD4DyU9lQ==
+"@aws-cdk/aws-sns@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.12.0.tgz#53c325adb634e5ae0e6645df0b44c6ae26982eb5"
+  integrity sha512-AwzJ+UqGStI1hwy6WKDii7Gp/ssF30a6c9wmodysfdxvZSKgKq3QBqkQVqYIg5eAZekdaomCpgFMbW1R8wPIZg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-sqs@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.9.0.tgz#73ab41b8a878fdb82e0fb428ee8dcd1d033d240c"
-  integrity sha512-AFgaAGPsXuYfBNRg5ckXKetYaM9hDqxyNL8H/dXOyqOlfuQpw71piI0ksVGyhkmQQ61fHZojp/zzEP4NurQjmw==
+"@aws-cdk/aws-sqs@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.12.0.tgz#f4a55a5ca043de9fa989a43d34fac22e17dc436f"
+  integrity sha512-/f4ZVqgmOGDKLSevwsA9MtCjwvTBGQ6S1mX8UdzHYbxnJYLmsXFysFJibZGoYy9Dxh9ZLe4dFTQmhZ5qSAcHtg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/aws-kms" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/aws-kms" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/aws-ssm@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.9.0.tgz#ebbc858a5cfc87379c5b1eb6627dc87a6d34ad10"
-  integrity sha512-9pCakaSkAMn/KYNZuBOSthtysmcb62cCXv9XC06nkSHLpnM4qytngTcCFhTNn9OFzVGVy8i69cubui3hGerJ1Q==
+"@aws-cdk/aws-ssm@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.12.0.tgz#da226199ec7d8804c2fd4a21ca08cfcbe424df96"
+  integrity sha512-RbSOZLiRvECjU1N+kbj0RPwretcEU5Xjtz4neuarSO4OyLM9Wcpbipm2rGS/+7A9rYVjJsIlrQ++3bhQAcjt6g==
   dependencies:
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/aws-stepfunctions@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.9.0.tgz#9ab2c8dce65a5e44fbc2abef1fc16f69abad6dcd"
-  integrity sha512-349/u0w3ocYen0Vv3Cqjui3HmgJC1ow2UXw15FVSK8c9iy3nEPJjgzFL3cRhynvS1Wt340bWU55fukICwsUfHQ==
+"@aws-cdk/aws-stepfunctions@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.12.0.tgz#07d04f54dae6e17065d51b8ab3e5fd64b9038b91"
+  integrity sha512-Qjzko1noRRH/fpADq24q7f1XREwuyl+ssxCkfP3qfXN63v54chnZm+hJjKayudhK6QPlJfajjkhxgtRrQouaSA==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "^1.9.0"
-    "@aws-cdk/aws-events" "^1.9.0"
-    "@aws-cdk/aws-iam" "^1.9.0"
-    "@aws-cdk/core" "^1.9.0"
+    "@aws-cdk/aws-cloudwatch" "^1.12.0"
+    "@aws-cdk/aws-events" "^1.12.0"
+    "@aws-cdk/aws-iam" "^1.12.0"
+    "@aws-cdk/core" "^1.12.0"
 
-"@aws-cdk/cfnspec@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.9.0.tgz#ed047fabd4648fc697e984dd472fa6bf7433a03f"
-  integrity sha512-Lo2WnUENNuUfPY8hzQPRntMEDExfguzx8QQhx7lvySyzxUWFzc2XOFD4i98jQRpikLcuBCShEplZCGsw21H++w==
+"@aws-cdk/cfnspec@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.12.0.tgz#52ab5978469d367318c0980c0d4a34e0fb0791a7"
+  integrity sha512-FkMrUNmAXIR+Ij7mDGZ7RT3RpkwK6fH/sO6KVBettpcE9JgKx2aP6hbq98pGScICrjpJ7V11H27Qr4pbmm6EbA==
   dependencies:
     md5 "^2.2.1"
 
-"@aws-cdk/cloudformation-diff@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.9.0.tgz#dc0daa069556775d3b5350f23b5310459ef8028f"
-  integrity sha512-MEjRvtYV5VHR8BTrjzxUeojVoV7Q+h+irpN6s7zhDKaxRSkix4tA459x/Nnxdu8lhoQLx+/dwpjHMUDemFpkNA==
+"@aws-cdk/cloudformation-diff@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.12.0.tgz#ffd3c073dc17c4d43a6125cf881dc3a57673bd92"
+  integrity sha512-tam1/oxnANO/l8A9/eL6BVs5Gj0IhSYOiv3SkMN/6rNcOS9t3XQd8h5RNPgvJizyqmDsFV9OFrWGcDBGPGfKfA==
   dependencies:
-    "@aws-cdk/cfnspec" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
-    colors "^1.3.3"
+    "@aws-cdk/cfnspec" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
+    colors "^1.4.0"
     diff "^4.0.1"
     fast-deep-equal "^2.0.1"
     source-map-support "^0.5.13"
     string-width "^4.1.0"
     table "^5.4.6"
 
-"@aws-cdk/core@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.9.0.tgz#8426ac4c56ea410c5664e30eb2a017b5783d5a89"
-  integrity sha512-f+2jy8IntW6e5j77vp6Gu2Zmbd9MwQ9r9n1ExL8uQa+3/3Ha53B7ZqTxB94SIei7CFY06+kxZHXXHVVJcYdHQQ==
+"@aws-cdk/core@^1.11.0", "@aws-cdk/core@^1.12.0", "@aws-cdk/core@^1.9.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.12.0.tgz#af418cbce34081106b7a9ec21c60e003e39c78a7"
+  integrity sha512-70eXa4Xv4F4NMISpGf+bkiUky8iQ04upByW9QJtqoxaFheg89pMVnMClqvAPs934C0ig97/gW2oQLIuY+0CrEg==
   dependencies:
-    "@aws-cdk/cx-api" "^1.9.0"
+    "@aws-cdk/cx-api" "^1.12.0"
 
-"@aws-cdk/cx-api@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.9.0.tgz#5eb2a5fc2a402342d37a80ea83155ddc306381a1"
-  integrity sha512-MASIUcOo0JtAZ5nLcuH6YmPrN6Q1s3QQsx7Ta0RVzbbiyfZxEMJkX70wkDY0NwaMJc8Rw2P36yj7PwSo27OU2w==
+"@aws-cdk/cx-api@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.12.0.tgz#abc81e589736b6aefa913a52fd49bb47030bd050"
+  integrity sha512-Qa2/WiOzW4BjgXzdqvxvea1A/i7DCQgiyzUlqYQM3e8Fj61SEPMOkF6pc5ulXkAXmqYdY3k+aG2nhfkp8dv51A==
   dependencies:
     semver "^6.3.0"
 
-"@aws-cdk/region-info@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.9.0.tgz#5f3a3b4f00e466d0deb08a28451c56fe224e360e"
-  integrity sha512-GX7oZRCgLx7Y0UV3BR8D1yFY7ikNAKBcegWoLWEFdDBZ7jAUiwYUrPfxEqz4l1bndtSBAptAhAmLL3Dshh9/4Q==
+"@aws-cdk/region-info@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.12.0.tgz#9b8bcc042ceb4da0d1569e7290a10a873e6c1376"
+  integrity sha512-eSNKN/rXpV9eVG5yuxxC1UpZULgljSKfRBjfoCmqgUBij5VXjGfsQ+g9whr65R3KIx4mSRYVYU0SimWZV+EF5g==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
@@ -619,7 +621,7 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.4.5":
+"@babel/runtime@^7.5.5":
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
   integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
@@ -815,6 +817,14 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@ndlib/ndlib-cdk@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@ndlib/ndlib-cdk/-/ndlib-cdk-1.0.3.tgz#ea78574b03401a2d826089de93c6b3b987a53160"
+  integrity sha512-Ae5bxjOYAiAq2pUd/zuo71lgM4ufzNOi+FvJ+jS/5gHRObsIdbRwUubsMdj40cF7fpE+a7kB+c4mhnwl9XLXHw==
+  dependencies:
+    "@aws-cdk/aws-elasticloadbalancingv2" "^1.9.0"
+    "@aws-cdk/core" "^1.9.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -880,10 +890,10 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/node@^8.0.7":
-  version "8.10.54"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.54.tgz#1c88eb253ac1210f1a5876953fb70f7cc4928402"
-  integrity sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==
+"@types/node@^12.7.11":
+  version "12.7.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
+  integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -896,16 +906,16 @@
   integrity sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
 
 "@types/yargs@^13.0.0":
-  version "13.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
-  integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.3.tgz#76482af3981d4412d65371a318f992d33464a380"
+  integrity sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
   dependencies:
     "@types/yargs-parser" "*"
 
 abab@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.1.tgz#3fa17797032b71410ec372e11668f4b4ffc86a82"
-  integrity sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.2.tgz#a2fba1b122c69a85caa02d10f9270c7219709a9d"
+  integrity sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==
 
 abbrev@1:
   version "1.1.1"
@@ -1122,18 +1132,18 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-cdk@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.9.0.tgz#a006162c9c3addcf1ca2be98b2f4dc4ae55db8c9"
-  integrity sha512-nbtyrdufJqVdFZrKE+OqI6QS4YPaJ4/RR0QMAbn1jNm52C91JXDEewFH7oSmzMXzzf5PMY0WMXoVD+z+ao/SzQ==
+aws-cdk@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.12.0.tgz#cc776c9abeffb53700c3f1ab2f28777df0258c42"
+  integrity sha512-uf+MpYXvJy8RZiMbHf/ogDA+U1bPqn9uIyAz/xsp0ml6IXtgJMWySqaHnxSLaReHU92PYEI/vk2NA609lZ68hg==
   dependencies:
-    "@aws-cdk/cloudformation-diff" "^1.9.0"
-    "@aws-cdk/cx-api" "^1.9.0"
-    "@aws-cdk/region-info" "^1.9.0"
+    "@aws-cdk/cloudformation-diff" "^1.12.0"
+    "@aws-cdk/cx-api" "^1.12.0"
+    "@aws-cdk/region-info" "^1.12.0"
     archiver "^3.1.1"
-    aws-sdk "^2.531.0"
+    aws-sdk "^2.543.0"
     camelcase "^5.3.1"
-    colors "^1.3.3"
+    colors "^1.4.0"
     decamelize "^3.2.0"
     fs-extra "^8.1.0"
     glob "^7.1.4"
@@ -1145,13 +1155,13 @@ aws-cdk@^1.9.0:
     semver "^6.3.0"
     source-map-support "^0.5.13"
     table "^5.4.6"
-    yaml "^1.6.0"
+    yaml "^1.7.0"
     yargs "^14.0.0"
 
-aws-sdk@^2.531.0:
-  version "2.534.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.534.0.tgz#72eac35c58651eb533044551e5fd06a7a8c8be79"
-  integrity sha512-0wm8mQg+N7vzOaFiM8wwvUXqWayf1ebqfi/SYVygASA79SnRe16pT73X2kEB/DbhXo+487Hf9p3hBGAsjoLcIA==
+aws-sdk@^2.543.0:
+  version "2.544.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.544.0.tgz#d99eeada8237ee67699ce6644f8070eeb84996e7"
+  integrity sha512-wwiBJgAUGKXY/xoCSrUXVZnNtefoH3YcPwGxQrQXOIDnLMQ32yh/SWc52qmwdxA7WJzpTcIj8y+5keH3P1LYaw==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -1392,9 +1402,9 @@ charenc@~0.0.1:
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
 chownr@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
-  integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.3.tgz#42d837d5239688d55f303003a508230fa6727142"
+  integrity sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -1457,7 +1467,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-colors@^1.3.3:
+colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -1469,10 +1479,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.12.1, commander@~2.20.0:
+commander@2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@^2.12.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.1.tgz#3863ce3ca92d0831dcf2a102f5fb4b5926afd0f9"
+  integrity sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -1581,11 +1596,9 @@ dashdash@^1.12.0:
     assert-plus "^1.0.0"
 
 data-uri-to-buffer@2:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-2.0.1.tgz#ca8f56fe38b1fd329473e9d1b4a9afcd8ce1c045"
-  integrity sha512-OkVVLrerfAKZlW2ZZ3Ve2y65jgiWqBKsTfUIAFbn8nVbPcCZg6l6gikKlEYv0kXcmzqGm6mFq/Jf2vriuEkv8A==
-  dependencies:
-    "@types/node" "^8.0.7"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz#d296973d5a4897a5dbe31716d118211921f04770"
+  integrity sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==
 
 data-urls@^1.0.0:
   version "1.1.0"
@@ -1769,9 +1782,9 @@ emoji-regex@^8.0.0:
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.3.tgz#9db9861620e47283cd49513be9c344f339ec5153"
-  integrity sha512-cbNhPFS6MlYlWTGncSiDYbdqKhwWFy7kNeb1YSOG6K65i/wPTkLVCJQj0hXA4j0m5Da+hBWnqopEnu1FFelisQ==
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
 
@@ -1783,9 +1796,9 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.5.1:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.2.tgz#7ce108fad83068c8783c3cdf62e504e084d8c497"
-  integrity sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.15.0.tgz#8884928ec7e40a79e3c9bc812d37d10c8b24cc57"
+  integrity sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==
   dependencies:
     es-to-primitive "^1.2.0"
     function-bind "^1.1.1"
@@ -1795,8 +1808,8 @@ es-abstract@^1.5.1:
     is-regex "^1.0.4"
     object-inspect "^1.6.0"
     object-keys "^1.1.1"
-    string.prototype.trimleft "^2.0.0"
-    string.prototype.trimright "^2.0.0"
+    string.prototype.trimleft "^2.1.0"
+    string.prototype.trimright "^2.1.0"
 
 es-to-primitive@^1.2.0:
   version "1.2.0"
@@ -2171,9 +2184,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.2:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.0.tgz#427391b584626c9c9c6ffb7d1fb90aa9789221cc"
-  integrity sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.2.tgz#8810a9821a9d6d52cb2f57d326d6ce7c3dfe741d"
+  integrity sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -2253,9 +2266,9 @@ has@^1.0.1, has@^1.0.3:
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
 hosted-git-info@^2.1.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz#44119abaf4bc64692a16ace34700fed9c03e2546"
-  integrity sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
+  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
@@ -3038,9 +3051,9 @@ json-stringify-safe@~5.0.1:
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@2.x, json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
     minimist "^1.2.0"
 
@@ -3292,20 +3305,20 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.2.1, minipass@^2.6.0, minipass@^2.8.6:
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.8.6.tgz#620d889ace26356391d010ecb9458749df9b6db5"
-  integrity sha512-lFG7d6g3+/UaFDCOtqPiKAC9zngWWsQZl1g5q6gaONqrjq61SX2xFqXMleQiFVyDpYwa018E9hmlAFY22PCb+A==
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
 minizlib@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.2.tgz#6f0ccc82fa53e1bf2ff145f220d2da9fa6e3a166"
-  integrity sha512-hR3At21uSrsjjDTWrbu0IMLTpnkpv8IIMFDFaoz43Tmu4LkmAXfH44vNNzpTnf+OAQQCHrb91y/wc2J4x5XgSQ==
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
   dependencies:
-    minipass "^2.2.1"
+    minipass "^2.9.0"
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -3363,13 +3376,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-ndlib-cdk@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ndlib-cdk/-/ndlib-cdk-1.0.2.tgz#3b9bffac7fee09a71d1c197d18242ed1236c3a9c"
-  integrity sha512-BmritdsseRziKQfNkIEEdUmn7qPZrgE60f5SLiCWYeqBqmKX3s/O70p4X18ZxwnMCGIa/JmuzXl/bovbKLYLuA==
-  dependencies:
-    "@aws-cdk/core" "^1.9.0"
 
 needle@^2.2.1:
   version "2.4.0"
@@ -3886,9 +3892,9 @@ rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-is@^16.8.4:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
-  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
+  integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -4420,7 +4426,7 @@ string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^5.2.0"
 
-string.prototype.trimleft@^2.0.0:
+string.prototype.trimleft@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
   integrity sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
@@ -4428,7 +4434,7 @@ string.prototype.trimleft@^2.0.0:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
 
-string.prototype.trimright@^2.0.0:
+string.prototype.trimright@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
   integrity sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
@@ -4532,9 +4538,9 @@ tar-stream@^2.1.0:
     readable-stream "^3.1.1"
 
 tar@^4:
-  version "4.4.12"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.12.tgz#6a1275a870a782f92828e24d28fa6aa253193af7"
-  integrity sha512-4GwpJwdSjIHlUrWd/1yJrl63UqcqjJyVglgIwn4gcG+Lrp9TXpZ1ZRrGLIRBNqLTUvz6yoPJrX4B/MISxY/Ukg==
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
@@ -4731,11 +4737,11 @@ typescript@^3.6.3:
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 uglify-js@^3.1.4:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
-  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.1.tgz#ae7688c50e1bdcf2f70a0e162410003cf9798311"
+  integrity sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==
   dependencies:
-    commander "~2.20.0"
+    commander "2.20.0"
     source-map "~0.6.1"
 
 union-value@^1.0.0:
@@ -4980,16 +4986,16 @@ yallist@^2.1.2:
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
-  integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.6.0.tgz#d8a985cfb26086dd73f91c637f6e6bc909fddd3c"
-  integrity sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==
+yaml@^1.7.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.1.tgz#86db1b39a6434a7928d3750cbe08303a50a24d6b"
+  integrity sha512-sR0mJ2C3LVBgMST+0zrrrsKSijbw64bfHmTt4nEXLZTZFyIAuUVARqA/LO5kaZav2OVQMaZ+5WRrZv7QjxG3uQ==
   dependencies:
-    "@babel/runtime" "^7.4.5"
+    "@babel/runtime" "^7.5.5"
 
 yargs-parser@10.x:
   version "10.1.0"
@@ -5002,6 +5008,14 @@ yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
   integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
+  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -5023,9 +5037,9 @@ yargs@^13.3.0:
     yargs-parser "^13.1.1"
 
 yargs@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.0.0.tgz#ba4cacc802b3c0b3e36a9e791723763d57a85066"
-  integrity sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.0.tgz#f116a9242c4ed8668790b40759b4906c276e76c3"
+  integrity sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==
   dependencies:
     cliui "^5.0.0"
     decamelize "^1.2.0"
@@ -5037,7 +5051,7 @@ yargs@^14.0.0:
     string-width "^3.0.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^13.1.1"
+    yargs-parser "^15.0.0"
 
 yn@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
There are two pipelines here. The "normal" one will monitor master, and includes "test" (where QA happens) and "prod". The prep pipeline monitors its own "prep" branch on usurper. This is to facilitate recent changes to the release process.

Prep will be triggered by pushes (e.g. merged PRs) into the prep branch. The main pipeline will trigger when a tag is added, to allow for the accumulation of multiple features before designating a release. A script has been written to automate the release preparation and adding the tag, and the CodePipeline does the rest of the work after that.