### PR TITLE
Mock urls in testlib

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -12,6 +12,8 @@
     "domainStackName": "libraries-domain",
     "sentryTokenPath": "/all/sentry/ci-token",
     "sentryOrg": "university-of-notre-dame-ts",
-    "sentryProject": "usurper"
+    "sentryProject": "usurper",
+    "libndAccount": "230391840102",
+    "testlibndAccount": "333680067100"
   }
 }

--- a/src/usurper-build-project.ts
+++ b/src/usurper-build-project.ts
@@ -1,6 +1,7 @@
 import codebuild = require('@aws-cdk/aws-codebuild')
 import { Role } from '@aws-cdk/aws-iam'
 import cdk = require('@aws-cdk/core')
+import { ICfnConditionExpression } from '@aws-cdk/core'
 
 export interface IUsurperBuildProjectProps extends codebuild.PipelineProjectProps {
   readonly stage: string
@@ -12,6 +13,7 @@ export interface IUsurperBuildProjectProps extends codebuild.PipelineProjectProp
   readonly sentryProject: string
   readonly createDns: boolean
   readonly domainStackName: string
+  readonly fakeServiceUrls?: ICfnConditionExpression
 }
 
 export class UsurperBuildProject extends codebuild.PipelineProject {
@@ -63,6 +65,10 @@ export class UsurperBuildProject extends codebuild.PipelineProject {
           },
           HOSTNAME_PREFIX: {
             value: scope.node.tryGetContext('hostnamePrefix') || serviceStackName,
+            type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          },
+          FAKE_SERVICE_URLS: {
+            value: (props.fakeServiceUrls || false).toString(),
             type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
           },
         },

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -8,7 +8,7 @@ import {
 import { Role, ServicePrincipal } from '@aws-cdk/aws-iam'
 import sns = require('@aws-cdk/aws-sns')
 import cdk = require('@aws-cdk/core')
-import { Fn, SecretValue } from '@aws-cdk/core'
+import { CfnCondition, Fn, SecretValue } from '@aws-cdk/core'
 import ArtifactBucket from './artifact-bucket'
 import UsurperBuildProject from './usurper-build-project'
 import UsurperBuildRole from './usurper-build-role'
@@ -99,12 +99,15 @@ export class UsurperPipelineStack extends cdk.Stack {
     ])
 
     // DEPLOY TO TEST
+    new CfnCondition(this, 'IsTestlib', {
+      expression: Fn.conditionEquals(this.account, this.node.tryGetContext('testlibndAccount')),
+    })
     const deployToTestProject = new UsurperBuildProject(this, 'UsurperTestBuildProject', {
       ...props,
       stage: 'test',
       role: codebuildRole,
       // "Test" stage needs to be able to build in testlibnd even without the existence of stacks for usurper's services
-      fakeServiceUrls: Fn.conditionEquals(this.account, this.node.tryGetContext('testlibndAccount')),
+      fakeServiceUrls: Fn.conditionIf('IsTestlib', 'true', 'false'),
     })
     const deployToTestAction = new CodeBuildAction({
       actionName: 'Build_and_Deploy',

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -8,7 +8,7 @@ import {
 import { Role, ServicePrincipal } from '@aws-cdk/aws-iam'
 import sns = require('@aws-cdk/aws-sns')
 import cdk = require('@aws-cdk/core')
-import { SecretValue } from '@aws-cdk/core'
+import { Fn, SecretValue } from '@aws-cdk/core'
 import ArtifactBucket from './artifact-bucket'
 import UsurperBuildProject from './usurper-build-project'
 import UsurperBuildRole from './usurper-build-role'
@@ -103,6 +103,8 @@ export class UsurperPipelineStack extends cdk.Stack {
       ...props,
       stage: 'test',
       role: codebuildRole,
+      // "Test" stage needs to be able to build in testlibnd even without the existence of stacks for usurper's services
+      fakeServiceUrls: Fn.conditionEquals(this.account, this.node.tryGetContext('testlibndAccount')),
     })
     const deployToTestAction = new CodeBuildAction({
       actionName: 'Build_and_Deploy',


### PR DESCRIPTION
While deploying "test" stage in testlibnd: ignore services usurper connects to because "prod" versions won't exist in libnd, and we don't want the pipeline to fail on looking up the exports in this case.