### PR TITLE
Add s3 bucket export name.

### DIFF
--- a/src/usurper-stack.ts
+++ b/src/usurper-stack.ts
@@ -88,10 +88,7 @@ export class UsurperStack extends cdk.Stack {
       comment: fqdn,
       aliasConfiguration: {
         acmCertRef: Fn.importValue(`${props.domainStackName}:ACMCertificateARN`),
-        names: [
-          fqdn,
-          // `${props.stage}.library.nd.edu`, <-- This will be added manually by ESU when cutting over to CI (?)
-        ],
+        names: [fqdn],
         securityPolicy: SecurityPolicyProtocol.TLS_V1_1_2016,
         sslMethod: SSLMethod.SNI,
       },
@@ -139,6 +136,7 @@ export class UsurperStack extends cdk.Stack {
     new CfnOutput(this, 'WebsiteBucketName', {
       value: bucket.bucketName,
       description: 'Name of S3 bucket to hold website content',
+      exportName: `usurperbucket-${props.stage}`,
     })
 
     // NOTE: If you deploy directly from blueprints, it will use whatever build happens to be sitting at the build path.


### PR DESCRIPTION
The old stack exported under this name. Now that the old stack is gone, we can reuse that export name and old scripts that referenced that bucket will work with the new one.