### PR TITLE
Use library.nd.edu domain instead of libraries.nd.edu.

### DIFF
--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -24,8 +24,8 @@ app.node.applyAspect(new StackTags())
 
 const stage = app.node.tryGetContext('stage') || 'dev'
 const sharedProps = {
-  createDns: app.node.tryGetContext('createDns') === undefined ? true : app.node.tryGetContext('createDns') === 'true',
-  domainStackName: app.node.tryGetContext('domainStackName') || 'libraries-domain',
+  createDns: app.node.tryGetContext('createDns') === undefined ? false : app.node.tryGetContext('createDns') === 'true',
+  domainStackName: app.node.tryGetContext('domainStackName'),
   hostnamePrefix: app.node.tryGetContext('hostnamePrefix') || `usurper`,
 }
 

--- a/cdk.json
+++ b/cdk.json
@@ -9,7 +9,7 @@
     "usurperBranch": "master",
     "blueprintsRepository": "usurper-blueprints",
     "blueprintsBranch": "master",
-    "domainStackName": "libraries-domain",
+    "domainStackName": "library-domain",
     "sentryTokenPath": "/all/sentry/ci-token",
     "sentryOrg": "university-of-notre-dame-ts",
     "sentryProject": "usurper",

--- a/src/usurper-stack.ts
+++ b/src/usurper-stack.ts
@@ -93,7 +93,7 @@ export class UsurperStack extends cdk.Stack {
       comment: fqdn,
       aliasConfiguration: {
         acmCertRef: Fn.importValue(`${props.domainStackName}:ACMCertificateARN`),
-        names: [fqdn],
+        names: [fqdn, `${props.stage}.${domainNameImport}`],
         securityPolicy: SecurityPolicyProtocol.TLS_V1_1_2016,
         sslMethod: SSLMethod.SNI,
       },


### PR DESCRIPTION
There was an issue that would have made prep.library.nd.edu fail SSL validation. However, the issue remained hidden for a while because of CloudFormation drift. A recent change reverted the drift so prep went down.

With Justin's help, we identified the problem and he set up a stack in testlibnd that provides a cert for library.nd.edu. This change just points to the new cert and adds an appropriate CNAME so we can host *.library.nd.edu sites correctly out of testlibnd.