### PR TITLE
Fix domain for automated QA and add email notifications.

### DIFF
--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -49,6 +49,7 @@ const pipelineProps = {
   sentryTokenPath: app.node.tryGetContext('sentryTokenPath'),
   sentryOrg: app.node.tryGetContext('sentryOrg'),
   sentryProject: app.node.tryGetContext('sentryProject'),
+  emailReceivers: app.node.tryGetContext('emailReceivers'),
 }
 new UsurperPipelineStack(app, 'PipelineStack', {
   ...pipelineProps,

--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -2,6 +2,7 @@
 import cdk = require('@aws-cdk/core')
 import { StackTags } from '@ndlib/ndlib-cdk'
 import { execSync } from 'child_process'
+import fs = require('fs')
 import { UsurperPipelineStack } from '../src/usurper-pipeline-stack'
 import { UsurperPrepPipelineStack } from '../src/usurper-prep-pipeline-stack'
 import { UsurperStack } from '../src/usurper-stack'
@@ -29,12 +30,18 @@ const sharedProps = {
   hostnamePrefix: app.node.tryGetContext('hostnamePrefix') || `usurper`,
 }
 
-new UsurperStack(app, 'AppStack', {
-  ...sharedProps,
-  stackName: app.node.tryGetContext('serviceStackName') || `usurper-${stage}`,
-  buildPath: app.node.tryGetContext('usurperBuildPath') || '../usurper/build',
-  stage,
-})
+let buildPath = app.node.tryGetContext('usurperBuildPath')
+if (!buildPath && fs.existsSync('../usurper/build')) {
+  buildPath = '../usurper/build'
+}
+if (buildPath) {
+  new UsurperStack(app, 'AppStack', {
+    ...sharedProps,
+    stackName: app.node.tryGetContext('serviceStackName') || `usurper-${stage}`,
+    buildPath,
+    stage,
+  })
+}
 
 const pipelineProps = {
   ...sharedProps,

--- a/cdk.json
+++ b/cdk.json
@@ -14,6 +14,7 @@
     "sentryOrg": "university-of-notre-dame-ts",
     "sentryProject": "usurper",
     "libndAccount": "230391840102",
-    "testlibndAccount": "333680067100"
+    "testlibndAccount": "333680067100",
+    "emailReceivers": "wse-notifications-group@nd.edu"
   }
 }

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -128,7 +128,9 @@ export class UsurperPipelineStack extends cdk.Stack {
     // QA
     const automatedTestQAProject = new QaProject(this, 'AutomatedQaProject', {
       role: codebuildRole,
-      testUrl: `test.` + Fn.importValue(`${props.domainStackName}:DomainName`),
+      testUrl:
+        (props.createDns ? `${props.hostnamePrefix}-test.` : 'test.') +
+        Fn.importValue(`${props.domainStackName}:DomainName`),
     })
     const automatedQaAction = new CodeBuildAction({
       actionName: 'Automated_QA',

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -9,6 +9,7 @@ import { Role, ServicePrincipal } from '@aws-cdk/aws-iam'
 import sns = require('@aws-cdk/aws-sns')
 import cdk = require('@aws-cdk/core')
 import { CfnCondition, Fn, SecretValue } from '@aws-cdk/core'
+import { PipelineNotifications } from '@ndlib/ndlib-cdk'
 import ArtifactBucket from './artifact-bucket'
 import QaProject from './qa-project'
 import UsurperBuildProject from './usurper-build-project'
@@ -31,6 +32,7 @@ export interface IUsurperPipelineStackProps extends cdk.StackProps {
   readonly createDns: boolean
   readonly domainStackName: string
   readonly hostnamePrefix: string
+  readonly emailReceivers: string
 }
 
 export class UsurperPipelineStack extends cdk.Stack {
@@ -56,6 +58,10 @@ export class UsurperPipelineStack extends cdk.Stack {
     const pipeline = new codepipeline.Pipeline(this, 'UsurperPipeline', {
       artifactBucket,
       role: codepipelineRole,
+    })
+    new PipelineNotifications(this, 'PipelineNotifications', {
+      pipeline,
+      receivers: props.emailReceivers,
     })
 
     // SOURCE CODE AND BLUEPRINTS
@@ -122,7 +128,7 @@ export class UsurperPipelineStack extends cdk.Stack {
     // QA
     const automatedTestQAProject = new QaProject(this, 'AutomatedQaProject', {
       role: codebuildRole,
-      testUrl: `${props.hostnamePrefix}-test.` + Fn.importValue(`${props.domainStackName}:DomainName`),
+      testUrl: `test.` + Fn.importValue(`${props.domainStackName}:DomainName`),
     })
     const automatedQaAction = new CodeBuildAction({
       actionName: 'Automated_QA',


### PR DESCRIPTION
Use test.library.nd.edu for QA because usurper-test.library.nd.edu doesn't actually exist. 😝 
Also add email notifications for pipeline state changes.

One more fix as well: Only include the UsurperStack if the path specified for the build exists. This way, it won't try to resolve the relative path when trying to deploy the pipeline (which resulted in an error even though the pipeline doesn't depend on it.)