### PR TITLE
LW-1053 Start website EC2 during pipeline execution.

### DIFF
--- a/bin/deploy.ts
+++ b/bin/deploy.ts
@@ -61,8 +61,10 @@ const pipelineProps = {
 new UsurperPipelineStack(app, 'PipelineStack', {
   ...pipelineProps,
   stackName: app.node.tryGetContext('pipelineStackName') || `usurper-pipeline`,
+  websiteTestServerStack: app.node.tryGetContext('websiteTestServerStack'),
 })
 new UsurperPrepPipelineStack(app, 'PrepPipelineStack', {
   ...pipelineProps,
   stackName: app.node.tryGetContext('pipelineStackName') || `usurper-prep-pipeline`,
+  websiteTestServerStack: app.node.tryGetContext('websiteTestServerStack'),
 })

--- a/cdk.json
+++ b/cdk.json
@@ -15,6 +15,7 @@
     "sentryProject": "usurper",
     "libndAccount": "230391840102",
     "testlibndAccount": "333680067100",
-    "emailReceivers": "wse-notifications-group@nd.edu"
+    "emailReceivers": "wse-notifications-group@nd.edu",
+    "websiteTestServerStack": "libnd-website4-linux-test"
   }
 }

--- a/src/qa-project.ts
+++ b/src/qa-project.ts
@@ -6,13 +6,14 @@ import cdk = require('@aws-cdk/core')
 export interface IQaProjectProps {
   readonly role: Role
   readonly testUrl: string
+  readonly ec2Id?: string
 }
 
 export class QaProject extends codebuild.PipelineProject {
   constructor(scope: cdk.Construct, id: string, props: IQaProjectProps) {
     const pipelineProps = {
       environment: {
-        buildImage: codebuild.LinuxBuildImage.fromDockerRegistry('postman/newman:4.5.4-ubuntu'),
+        buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2,
       },
       environmentVariables: {
         CI: { value: 'true', type: BuildEnvironmentVariableType.PLAINTEXT },
@@ -22,8 +23,20 @@ export class QaProject extends codebuild.PipelineProject {
         version: '0.2',
         phases: {
           install: {
-            commands: ['echo "Ensure that the Newman spec is readable"', 'chmod -R 755 ./scripts/codebuild/spec/*'],
+            'runtime-versions': {
+              nodejs: '12.x',
+            },
+            commands: [
+              'npm install -g newman',
+              'echo "Ensure that the Newman spec is readable"',
+              'chmod -R 755 ./scripts/codebuild/spec/*'
+            ],
           },
+          pre_build: props.ec2Id ? {
+            commands: [
+              `aws ec2 start-instances --instance-ids "${props.ec2Id}"`,
+            ],
+          } : null,
           build: {
             commands: [
               'echo "Beginning tests at `date`"',

--- a/src/usurper-build-role.ts
+++ b/src/usurper-build-role.ts
@@ -8,6 +8,7 @@ export interface IUsurperBuildRoleProps extends RoleProps {
   readonly artifactBucket: Bucket
   readonly createDns: boolean
   readonly domainStackName: string
+  readonly ec2Id?: string
 }
 
 export class UsurperBuildRole extends Role {
@@ -188,6 +189,18 @@ export class UsurperBuildRole extends Role {
       )
     })
     this.addToPolicy(ssmStatement)
+
+    // Allow pipeline to start EC2 instances in case it is not running when QA action runs
+    if (props.ec2Id) {
+      this.addToPolicy(
+        new PolicyStatement({
+          resources: [
+            Fn.sub('arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/${ec2Id}', { ec2Id: props.ec2Id }),
+          ],
+          actions: ['ec2:StartInstances'],
+        }),
+      )
+    }
   }
 }
 

--- a/src/usurper-pipeline-stack.ts
+++ b/src/usurper-pipeline-stack.ts
@@ -33,11 +33,14 @@ export interface IUsurperPipelineStackProps extends cdk.StackProps {
   readonly domainStackName: string
   readonly hostnamePrefix: string
   readonly emailReceivers: string
+  readonly websiteTestServerStack?: string
 }
 
 export class UsurperPipelineStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props: IUsurperPipelineStackProps) {
     super(scope, id, props)
+
+    const ec2Id = props.websiteTestServerStack ? cdk.Fn.importValue(`${props.websiteTestServerStack}:InstanceId`) : undefined
 
     // S3 BUCKET FOR STORING ARTIFACTS
     const artifactBucket = new ArtifactBucket(this, 'ArtifactBucket', {})
@@ -52,6 +55,7 @@ export class UsurperPipelineStack extends cdk.Stack {
       artifactBucket,
       createDns: props.createDns,
       domainStackName: props.domainStackName,
+      ec2Id,
     })
 
     // CREATE PIPELINE
@@ -131,6 +135,7 @@ export class UsurperPipelineStack extends cdk.Stack {
       testUrl:
         (props.createDns ? `${props.hostnamePrefix}-test.` : 'test.') +
         Fn.importValue(`${props.domainStackName}:DomainName`),
+      ec2Id,
     })
     const automatedQaAction = new CodeBuildAction({
       actionName: 'Automated_QA',


### PR DESCRIPTION
This _should_ start the EC2 instance if before running unit tests. I can't really test it since I can't deploy to libnd and we don't have an equivalent EC2 in testlibnd.

What I did make sure is that you can override the `websiteTestServerStack` with an empty string to skip the step, so the pipeline can still be deployed to testlibnd and run successfully.